### PR TITLE
fix: add service unavailable http status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,26 +100,3 @@ jobs:
           distribution: 'corretto'
       - name: Build
         run: ./gradlew build
-
-  # ---------------------------------------------------------------
-  # job: release
-  #
-  # Perform after commits and build successfully complete on "master"
-  #
-  # * Creates and maintains "release PR"
-  # * Creates release when the "release PR" is merged to "master"
-  #
-  # See: https://github.com/google-github-actions/release-please-action
-  # See: https://github.com/googleapis/release-please
-  #
-  release:
-    needs: [build, validate, scan]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: google-github-actions/release-please-action@v3.5.0
-        with:
-          include-v-in-tag: false
-          release-type: simple
-          extra-files: |
-            build.gradle
-            README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
-name: release_manual
+name: release
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
 
 jobs:
   # ---------------------------------------------------------------
   # job: release
   #
-  # Perform after commits and build successfully complete on "master"
+  # Manually invoke to rerun release-please
   #
   # * Creates and maintains "release PR"
   # * Creates release when the "release PR" is merged to "master"
@@ -15,12 +18,12 @@ jobs:
   # See: https://github.com/google-github-actions/release-please-action
   # See: https://github.com/googleapis/release-please
   #
-  release_manual:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3.5.0
         with:
-          include-v-in-tag: false
+          include-v-in-tag: true
           release-type: simple
           extra-files: |
             build.gradle

--- a/common/src/main/java/com/mx/common/accessors/PathResponseStatus.java
+++ b/common/src/main/java/com/mx/common/accessors/PathResponseStatus.java
@@ -98,7 +98,12 @@ public enum PathResponseStatus {
   /**
    * A request failed to respond in less than expected time.
    */
-  TIMEOUT(504, "Timeout", true);
+  TIMEOUT(504, "Timeout", true),
+
+  /**
+   * The upstream service
+   */
+  UPSTREAM_SERVICE_UNAVAILABLE(531, "Upstream service unavailable", true);
 
   private final String description;
 

--- a/common/src/main/java/com/mx/common/http/HttpStatus.java
+++ b/common/src/main/java/com/mx/common/http/HttpStatus.java
@@ -427,7 +427,12 @@ public enum HttpStatus {
    * {@code 511 Network Authentication Required}.
    * @see <a href="https://tools.ietf.org/html/rfc6585#section-6">Additional HTTP Status Codes</a>
    */
-  NETWORK_AUTHENTICATION_REQUIRED(511, "Network Authentication Required");
+  NETWORK_AUTHENTICATION_REQUIRED(511, "Network Authentication Required"),
+  /**
+   * {@code 531 Upstream Service Unavailable}.
+   * Note: This is a custom code used to indicate that an upstream service call failed or is unavailable
+   */
+  UPSTREAM_SERVICE_UNAVAILABLE(531, "Upstream Service Unavailable");
 
   private final int value;
 
@@ -635,6 +640,7 @@ public enum HttpStatus {
     map.put(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED, PathResponseStatus.OK);
     map.put(HttpStatus.NOT_EXTENDED, PathResponseStatus.INTERNAL_ERROR);
     map.put(HttpStatus.NETWORK_AUTHENTICATION_REQUIRED, PathResponseStatus.NOT_ALLOWED);
+    map.put(HttpStatus.UPSTREAM_SERVICE_UNAVAILABLE, PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
 
     // This is just a sanity check to make sure we don't accidentally create a bad mapping.
     map.forEach((httpStatus, pathResponseStatus) -> {

--- a/common/src/test/groovy/com/mx/common/http/HttpStatusTest.groovy
+++ b/common/src/test/groovy/com/mx/common/http/HttpStatusTest.groovy
@@ -84,5 +84,6 @@ class HttpStatusTest extends Specification {
     HttpStatus.BANDWIDTH_LIMIT_EXCEEDED                  || PathResponseStatus.OK
     HttpStatus.NOT_EXTENDED                              || PathResponseStatus.INTERNAL_ERROR
     HttpStatus.NETWORK_AUTHENTICATION_REQUIRED           || PathResponseStatus.NOT_ALLOWED
+    HttpStatus.UPSTREAM_SERVICE_UNAVAILABLE              || PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE
   }
 }


### PR DESCRIPTION
# Summary of change

Add support for 531 Upstream Service Unavailable http status.

## Downstream impact

This new status is not an officially-support HTTP status. If the status is unacceptable, then a filter may be needed to change it to something standard. The inclusion helps provide trouble-shooting information to the caller about why a valid call failed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
