### PR TITLE
fix: duration serialization fail on null

### DIFF
--- a/common/src/main/java/com/mx/common/serialization/DurationTypeAdapter.java
+++ b/common/src/main/java/com/mx/common/serialization/DurationTypeAdapter.java
@@ -1,0 +1,23 @@
+package com.mx.common.serialization;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.mx.common.lang.Durations;
+
+public class DurationTypeAdapter extends TypeAdapter<Duration> {
+  @Override
+  public final void write(JsonWriter out, Duration value) throws IOException {
+    if (value != null) {
+      out.value(Durations.toCompactString(value));
+    }
+  }
+
+  @Override
+  public final Duration read(JsonReader in) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/common/src/test/groovy/com/mx/common/serialization/ConfigurationTypeAdapterTest.groovy
+++ b/common/src/test/groovy/com/mx/common/serialization/ConfigurationTypeAdapterTest.groovy
@@ -1,18 +1,21 @@
-package com.mx.common.configuration
+package com.mx.common.serialization
+
+import java.time.Duration
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.mx.testing.serialization.ConfigurationWithDuration
 import com.mx.testing.serialization.ConfigurationWithSecrets
 
 import spock.lang.Specification
 
-class ConfigurationSerializerTest extends Specification {
+class ConfigurationTypeAdapterTest extends Specification {
   Gson subject
 
   void setup() {
     subject = new GsonBuilder()
         .setPrettyPrinting()
-        .registerTypeAdapterFactory(new ConfigurationSerializer.Factory())
+        .registerTypeAdapterFactory(new ConfigurationTypeAdapter.Factory())
         .create()
   }
 
@@ -106,5 +109,28 @@ class ConfigurationSerializerTest extends Specification {
 
     then:
     deserialized.secret == null
+  }
+
+  def "serializes durations"() {
+    given:
+    def configuration = new ConfigurationWithDuration().tap {
+      setDuration(Duration.ofSeconds(12))
+    }
+
+    when:
+    def result = subject.toJson(configuration)
+
+    then:
+    result.contains("duration")
+    result.contains("12s")
+
+
+    when:
+    configuration.setDuration()
+    result = subject.toJson(configuration)
+    println(result)
+
+    then:
+    !result.contains("duration")
   }
 }

--- a/common/src/test/groovy/com/mx/testing/Account.java
+++ b/common/src/test/groovy/com/mx/testing/Account.java
@@ -1,10 +1,12 @@
 package com.mx.testing;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import com.mx.common.models.MdxBase;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class Account extends MdxBase<Account> {
   private String id;
 }

--- a/common/src/test/java/com/mx/testing/serialization/ConfigurationWithDuration.java
+++ b/common/src/test/java/com/mx/testing/serialization/ConfigurationWithDuration.java
@@ -1,0 +1,13 @@
+package com.mx.testing.serialization;
+
+import java.time.Duration;
+
+import lombok.Data;
+
+import com.mx.common.configuration.ConfigurationField;
+
+@Data
+public class ConfigurationWithDuration {
+  @ConfigurationField
+  private Duration duration;
+}

--- a/gateway/src/main/java/com/mx/path/gateway/configuration/ConfigurationBinder.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/ConfigurationBinder.java
@@ -14,11 +14,11 @@ import com.google.gson.GsonBuilder;
 import com.mx.common.collections.ObjectArray;
 import com.mx.common.collections.ObjectMap;
 import com.mx.common.configuration.ConfigurationField;
-import com.mx.common.configuration.ConfigurationSerializer;
 import com.mx.common.lang.Strings;
 import com.mx.common.reflection.Annotations;
 import com.mx.common.reflection.Constructors;
 import com.mx.common.reflection.Fields;
+import com.mx.common.serialization.ConfigurationTypeAdapter;
 import com.mx.path.gateway.configuration.annotations.ClientID;
 import com.mx.path.utilities.reflection.ClassHelper;
 
@@ -36,7 +36,7 @@ public class ConfigurationBinder {
   private static final Logger LOGGER = LoggerFactory.getLogger(GatewayObjectConfigurator.class);
   private static final Gson GSON = new GsonBuilder()
       .setPrettyPrinting()
-      .registerTypeAdapterFactory(new ConfigurationSerializer.Factory())
+      .registerTypeAdapterFactory(new ConfigurationTypeAdapter.Factory())
       .create();
 
   private final ConfigurationState state;
@@ -72,7 +72,7 @@ public class ConfigurationBinder {
     try {
       LOGGER.debug("Configuration binding: " + configuration.getClass().getName() + " -> " + GSON.toJson(configuration));
     } catch (Exception e) {
-      LOGGER.warn("Unable to serialize configuration: " + configuration.getClass().getName());
+      LOGGER.warn("Unable to serialize configuration: " + configuration.getClass().getName(), e);
     }
   }
 


### PR DESCRIPTION
# Summary of Changes

When serializing configurations, Durations fail when null, also need to use a TypeAdapter for durations so that serialization will work in JDK 17.

Cleanup: Also renaming ConfigurationSerializer and moving into serialization package.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
