### PR TITLE
test: add withMatcher to RequestMatcher

### DIFF
--- a/testing/src/main/java/com/mx/path/testing/request/RequestMatcher.java
+++ b/testing/src/main/java/com/mx/path/testing/request/RequestMatcher.java
@@ -55,6 +55,12 @@ public class RequestMatcher {
     return this;
   }
 
+  public final RequestMatcher withMatcher(Function<Request<?, ?>, Boolean> check) {
+    descriptions.add("with matcher");
+    assertions.add(check);
+    return this;
+  }
+
   public final RequestMatcher exactly(Request<?, ?> exactRequest) {
     descriptions.add("with exact request");
     assertions.add(exactRequest::equals);


### PR DESCRIPTION
# Summary of Changes

Adding `withMatcher` since `with` conflicts with a global groovy function.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
