### PR TITLE
fix: update connect exception statuses and set codes

### DIFF
--- a/common/src/main/java/com/mx/common/connect/ServiceUnavailableException.java
+++ b/common/src/main/java/com/mx/common/connect/ServiceUnavailableException.java
@@ -15,7 +15,8 @@ import com.mx.common.exception.PathRequestException;
 public class ServiceUnavailableException extends ConnectException {
   public ServiceUnavailableException(String message, Throwable cause) {
     super(message, cause);
+    setCode(String.valueOf(PathResponseStatus.UNAVAILABLE.value()));
     setReport(false);
-    setStatus(PathResponseStatus.UNAVAILABLE);
+    setStatus(PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
   }
 }

--- a/common/src/main/java/com/mx/common/connect/TimeoutException.java
+++ b/common/src/main/java/com/mx/common/connect/TimeoutException.java
@@ -10,17 +10,20 @@ import com.mx.common.exception.PathRequestException;
  */
 public class TimeoutException extends ConnectException {
   public TimeoutException() {
-    super("A request timeout occurred", PathResponseStatus.TIMEOUT);
+    super("A request timeout occurred", PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
+    setCode(String.valueOf(PathResponseStatus.TIMEOUT.value()));
     setReport(false);
   }
 
   public TimeoutException(String message) {
-    super(message, PathResponseStatus.TIMEOUT);
+    super(message, PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
+    setCode(String.valueOf(PathResponseStatus.TIMEOUT.value()));
     setReport(false);
   }
 
   public TimeoutException(String message, Throwable cause) {
-    super(message, PathResponseStatus.TIMEOUT, cause);
+    super(message, PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE, cause);
+    setCode(String.valueOf(PathResponseStatus.TIMEOUT.value()));
     setReport(false);
   }
 }

--- a/common/src/main/java/com/mx/common/connect/TooManyRequestsException.java
+++ b/common/src/main/java/com/mx/common/connect/TooManyRequestsException.java
@@ -13,7 +13,8 @@ import com.mx.common.exception.PathRequestException;
 public class TooManyRequestsException extends ConnectException {
   public TooManyRequestsException(String message, Throwable cause) {
     super(message, cause);
+    setCode(String.valueOf(PathResponseStatus.TOO_MANY_REQUESTS.value()));
     setReport(false);
-    setStatus(PathResponseStatus.TOO_MANY_REQUESTS);
+    setStatus(PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
   }
 }


### PR DESCRIPTION
Updating statuses on connection exceptions to bring them in line with upstream system failure standards. Should respond with a 531. Setting code to previous status codes to help provide more information about the failure.

# Summary of Changes

Updating statuses on connection exceptions to bring them in line with upstream system failure standards. Should respond with a 531. Setting code to previous status codes to help provide more information about the failure.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
