### PR TITLE
Add overridable afterGatewayInitialized lifecycle function to Configurator

### DIFF
--- a/common/src/main/java/com/mx/common/gateway/GatewayBaseClass.java
+++ b/common/src/main/java/com/mx/common/gateway/GatewayBaseClass.java
@@ -5,6 +5,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Used by gateway annotation processor to generate gateways. Place on the gateway base class to be used for all
+ * generated gateways
+ *
+ * <p>
+ * todo: V2 - Move to gateway project
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GatewayBaseClass {
@@ -16,4 +23,9 @@ public @interface GatewayBaseClass {
   // todo: Figure out how to constrain this to extends Accessor
   Class<?> target();
 
+  /**
+   * Class name for an implementation of GatewayInitializer (in gateway project)
+   * @return
+   */
+  String initializer() default "";
 }

--- a/gateway-generator/src/main/java/com/mx/path/api/GatewayConfiguratorGenerator.java
+++ b/gateway-generator/src/main/java/com/mx/path/api/GatewayConfiguratorGenerator.java
@@ -1,16 +1,17 @@
 package com.mx.path.api;
 
-import java.io.IOException;
+import com.mx.common.lang.Strings;
+import com.mx.path.gateway.configuration.Configurator;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeSpec;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
-
-import com.mx.path.gateway.configuration.Configurator;
-import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.JavaFile;
-import com.squareup.javapoet.ParameterizedTypeName;
-import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
 
 public class GatewayConfiguratorGenerator {
   private final Filer filer;
@@ -25,6 +26,14 @@ public class GatewayConfiguratorGenerator {
         .superclass(ParameterizedTypeName.get(
             ClassName.get(Configurator.class),
             ClassName.get(target.getBasePackage(), target.getSimpleName())));
+
+    if (Strings.isNotBlank(target.getAnnotation().initializer())) {
+      configuratorClass.addMethod(
+          MethodSpec.constructorBuilder()
+              .addStatement("this.addInitializer(new $T())", ClassName.bestGuess(target.getAnnotation().initializer()))
+              .build()
+      );
+    }
 
     JavaFile javaFile = JavaFile.builder(target.getBasePackage(), configuratorClass.build())
         .addFileComment("---------------------------------------------------------------------------------------------------------------------\n"

--- a/gateway/src/main/java/com/mx/path/gateway/configuration/GatewayInitializer.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/GatewayInitializer.java
@@ -1,0 +1,19 @@
+package com.mx.path.gateway.configuration;
+
+import com.mx.common.gateway.GatewayBaseClass;
+import com.mx.path.gateway.Gateway;
+
+import java.util.Map;
+
+/**
+ * Implement to provide custom gateway initialization in Gateway flavour project
+ *
+ * <p>Specify the implementation using the {@link GatewayBaseClass} annotation
+ *
+ * <p>
+ * todo: V2 - move to Gateway project and change param types from Object to Gateway
+ */
+public interface GatewayInitializer {
+  default void afterGatewaysInitialized(Map<String, Gateway<?>> gateways) {
+  }
+}

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfiguratorTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfiguratorTest.groovy
@@ -1,0 +1,44 @@
+package com.mx.path.gateway.configuration
+
+
+import com.mx.testing.gateway.BaseGateway
+
+import spock.lang.Specification
+
+class ConfiguratorTest extends Specification {
+  class AfterGatewayInitializedConfigurator extends Configurator<BaseGateway> {
+  }
+
+  class TestGatewayInitializer implements GatewayInitializer<BaseGateway> {
+    def hookCalledWith
+    def invokeCount = 0
+
+    @Override
+    void afterGatewaysInitialized(Map<String, BaseGateway> gateways) {
+      hookCalledWith = gateways
+      invokeCount++
+    }
+  }
+
+  def "invokes afterGatewaysInitialized hook"() {
+    given:
+    def yaml =
+        "client:\n" +
+        "  accessor:\n" +
+        "    class: com.mx.testing.accessors.BaseAccessor\n" +
+        "    scope: singleton\n" +
+        "  gateways:\n" +
+        "    accounts: {}\n"
+
+    def initializer = new TestGatewayInitializer()
+    def subject = new AfterGatewayInitializedConfigurator()
+    subject.setInitializer(initializer)
+
+    when:
+    def gateways = subject.buildFromYaml(yaml)
+
+    then:
+    initializer.getHookCalledWith() == gateways
+    initializer.invokeCount == 1
+  }
+}

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/GatewayObjectConfiguratorTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/GatewayObjectConfiguratorTest.groovy
@@ -7,6 +7,7 @@ import com.mx.path.gateway.service.GatewayService
 import com.mx.testing.MessageBrokerImpl
 import com.mx.testing.binding.BehaviorWithClientIDAndConfiguration
 import com.mx.testing.binding.BindedConfigGatewayService
+import com.mx.testing.gateway.BaseGateway
 
 import spock.lang.Specification
 

--- a/gateway/src/test/java/com/mx/testing/gateway/BaseGateway.java
+++ b/gateway/src/test/java/com/mx/testing/gateway/BaseGateway.java
@@ -3,12 +3,19 @@ package com.mx.testing.gateway;
 import lombok.experimental.SuperBuilder;
 
 import com.mx.path.gateway.Gateway;
+import com.mx.path.gateway.configuration.AccessorProxyMap;
 import com.mx.path.gateway.configuration.RootGateway;
 import com.mx.testing.accessors.BaseAccessor;
+import com.mx.testing.accessors.proxy.BaseAccessorProxySingleton;
 
 @RootGateway
 @SuperBuilder
 public class BaseGateway extends Gateway<BaseAccessor> {
+
+  static {
+    AccessorProxyMap.add("singleton", BaseAccessor.class, BaseAccessorProxySingleton.class);
+  }
+
   public BaseGateway() {
   }
 


### PR DESCRIPTION
# Summary of Changes

Add overridable `afterGatewayInitialized` to Configurator with empty body. This is called after all gateways have been initialized, allowing concrete Configurators to add their own post initialization code.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
