### PR TITLE
fix: handle more specific HttpClient exceptions

### DIFF
--- a/gateway/src/main/java/com/mx/path/gateway/connect/filters/HttpClientConnectException.java
+++ b/gateway/src/main/java/com/mx/path/gateway/connect/filters/HttpClientConnectException.java
@@ -1,0 +1,12 @@
+package com.mx.path.gateway.connect.filters;
+
+import com.mx.common.accessors.PathResponseStatus;
+import com.mx.common.connect.ConnectException;
+
+public class HttpClientConnectException extends ConnectException {
+  public HttpClientConnectException(String message, Throwable cause) {
+    super(message, cause);
+    withStatus(PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
+    withReport(true); // todo: for now. We will probably want to change this once we nail down the http client exceptions.
+  }
+}


### PR DESCRIPTION
# Summary of Changes

Introduce new exception type and catch more targeted exceptions in `HttpClientFilter` and `HttpClientExecutor`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
