### PR TITLE
fix: expose the current ConfigurationState

### DIFF
--- a/gateway/src/main/java/com/mx/path/gateway/configuration/ConfigurationState.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/ConfigurationState.java
@@ -3,6 +3,8 @@ package com.mx.path.gateway.configuration;
 import java.util.Stack;
 import java.util.function.Supplier;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import com.mx.common.lang.Strings;
 
 import org.slf4j.Logger;
@@ -19,7 +21,8 @@ public final class ConfigurationState {
 
   private static ConfigurationState current = new ConfigurationState();
 
-  static ConfigurationState getCurrent() {
+  @SuppressFBWarnings("MS_EXPOSE_REP")
+  public static ConfigurationState getCurrent() {
     return current;
   }
 


### PR DESCRIPTION
# Summary of Changes

I think this was an oversight. We may need to get access to the current configuration state from outside of the configurator context.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
