### PR TITLE
fix: allow gateway generator to support accessor and accessors package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id "idea"
   id "com.github.mxenabled.vogue" version "1.0.2"
-  id "com.github.mxenabled.coppuccino" version "3.2.1" apply false
+  id "com.github.mxenabled.coppuccino" version "3.2.9" apply false
   id "io.freefair.lombok" version "6.5.1" apply false
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }

--- a/gateway-generator/src/main/java/com/mx/path/api/AccessorProxyGenerator.java
+++ b/gateway-generator/src/main/java/com/mx/path/api/AccessorProxyGenerator.java
@@ -262,7 +262,7 @@ public class AccessorProxyGenerator {
   }
 
   private String calculatePackageName(Class<? extends Accessor> accessorClass) {
-    String packageClass = accessorClass.getPackage().getName().replaceAll(".*\\.accessors[.]*", "");
+    String packageClass = accessorClass.getPackage().getName().replaceAll(".*\\.accessors?[.]*", "");
     if (Strings.isBlank(packageClass)) {
       return "com.mx.path.gateway.accessor.proxy";
     }

--- a/gateway-generator/src/main/java/com/mx/path/api/remote/RemoteAccessorGenerator.java
+++ b/gateway-generator/src/main/java/com/mx/path/api/remote/RemoteAccessorGenerator.java
@@ -226,7 +226,7 @@ public final class RemoteAccessorGenerator {
   }
 
   private String calculatePackageName(Class<? extends Accessor> accessorClass) {
-    String packageClass = accessorClass.getPackage().getName().replaceAll(".*\\.accessors[.]*", "");
+    String packageClass = accessorClass.getPackage().getName().replaceAll(".*\\.accessors?[.]*", "");
     if (Strings.isBlank(packageClass)) {
       return "com.mx.path.gateway.accessor.remote";
     }


### PR DESCRIPTION
# Summary of Changes

This is only a backward compatibility tweak. This code will be reworked in v2 to remove the hard-coded package path and calculate the package path given inputs.

Tested this with new and old MDX package paths to ensure no impact.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
