### PR TITLE
docs: add ServiceIdentifier.Session to v2 upgrade script

### DIFF
--- a/upgrades/v2/core-2-upgrade.sh
+++ b/upgrades/v2/core-2-upgrade.sh
@@ -70,6 +70,7 @@ function process_file {
     "com.mx.common.models.MdxWrappable([^a-zA-Z])=com.mx.common.models.ModelWrappable\1"
     "com.mx.common.remote.MdxListOfJson([^a-zA-Z])=com.mx.common.models.ParameterizedTypeImpl\1"
     "com.mx.path.model.mdx.model.MdxWrappableSerializer([^a-zA-Z])=com.mx.path.model.mdx.model.ModelWrappableSerializer\1"
+    "Session.ServiceIdentifier.Session([^a-zA-Z])=Scope.Session\1"
 
     #"([^a-zA-Z])com.mx.common.process.FaultTolerantExecutionFailureStatus([^a-zA-Z])=\1com.mx.common.accessors.PathResponseStatus\2"
   )
@@ -79,6 +80,7 @@ function process_file {
     "com.mx.common.models.MdxWrappable([^a-zA-Z]?)=com.mx.common.models.ModelWrappable\1"
     "com.mx.common.remote.MdxListOfJson([^a-zA-Z]?)=com.mx.common.models.ParameterizedTypeImpl\1"
     "com.mx.path.model.mdx.model.MdxWrappableSerializer([^a-zA-Z]?)=com.mx.path.model.mdx.model.ModelWrappableSerializer\1"
+    "Session.ServiceIdentifier.Session([^a-zA-Z]?)=Scope.Session\1"
 
     #"com.mx.serializers.YamlSerializer([^a-zA-Z]?)=com.mx.common.serialization.ObjectMapYamlDeserializer\1"
     #"([^a-zA-Z])YamlSerializer([^a-zA-Z]?)=\1ObjectMapYamlDeserializer\2"


### PR DESCRIPTION
# Summary of Changes

Adding easy ServiceIdentifier.Session migration to v2 upgrade script.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
