### PR TITLE
Rename certificates package

### DIFF
--- a/http/src/main/java/com/mx/path/connect/http/HttpClientFilter.java
+++ b/http/src/main/java/com/mx/path/connect/http/HttpClientFilter.java
@@ -12,8 +12,8 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 
 import com.google.gson.Gson;
-import com.mx.path.connect.http.certificates.MutualAuthProvider;
-import com.mx.path.connect.http.certificates.MutualAuthProviderFactory;
+import com.mx.path.connect.http.certificate.MutualAuthProvider;
+import com.mx.path.connect.http.certificate.MutualAuthProviderFactory;
 import com.mx.path.core.common.collection.MultiValueMap;
 import com.mx.path.core.common.collection.SingleValueMap;
 import com.mx.path.core.common.connect.ConnectException;

--- a/http/src/main/java/com/mx/path/connect/http/certificate/FieldSettingsValidationError.java
+++ b/http/src/main/java/com/mx/path/connect/http/certificate/FieldSettingsValidationError.java
@@ -1,4 +1,4 @@
-package com.mx.path.connect.http.certificates;
+package com.mx.path.connect.http.certificate;
 
 import java.util.List;
 

--- a/http/src/main/java/com/mx/path/connect/http/certificate/KeyStoreBuilder.java
+++ b/http/src/main/java/com/mx/path/connect/http/certificate/KeyStoreBuilder.java
@@ -1,4 +1,4 @@
-package com.mx.path.connect.http.certificates;
+package com.mx.path.connect.http.certificate;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/http/src/main/java/com/mx/path/connect/http/certificate/LoadedKeystore.java
+++ b/http/src/main/java/com/mx/path/connect/http/certificate/LoadedKeystore.java
@@ -1,4 +1,4 @@
-package com.mx.path.connect.http.certificates;
+package com.mx.path.connect.http.certificate;
 
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/http/src/main/java/com/mx/path/connect/http/certificate/MutualAuthProvider.java
+++ b/http/src/main/java/com/mx/path/connect/http/certificate/MutualAuthProvider.java
@@ -1,4 +1,4 @@
-package com.mx.path.connect.http.certificates;
+package com.mx.path.connect.http.certificate;
 
 import org.apache.http.impl.client.HttpClientBuilder;
 

--- a/http/src/main/java/com/mx/path/connect/http/certificate/MutualAuthProviderFactory.java
+++ b/http/src/main/java/com/mx/path/connect/http/certificate/MutualAuthProviderFactory.java
@@ -1,4 +1,4 @@
-package com.mx.path.connect.http.certificates;
+package com.mx.path.connect.http.certificate;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/http/src/main/java/com/mx/path/connect/http/certificate/MutualAuthProviderKeystore.java
+++ b/http/src/main/java/com/mx/path/connect/http/certificate/MutualAuthProviderKeystore.java
@@ -1,4 +1,4 @@
-package com.mx.path.connect.http.certificates;
+package com.mx.path.connect.http.certificate;
 
 import java.net.Socket;
 import java.security.KeyManagementException;

--- a/http/src/test/groovy/com/mx/path/api/connect/http/certificate/LoadedKeystoreTest.groovy
+++ b/http/src/test/groovy/com/mx/path/api/connect/http/certificate/LoadedKeystoreTest.groovy
@@ -1,6 +1,6 @@
-package com.mx.path.api.connect.http.certificates
+package com.mx.path.api.connect.http.certificate
 
-import com.mx.path.connect.http.certificates.LoadedKeystore
+import com.mx.path.connect.http.certificate.LoadedKeystore
 
 import spock.lang.Specification
 

--- a/http/src/test/groovy/com/mx/path/api/connect/http/certificate/MutualAuthProviderFactoryTest.groovy
+++ b/http/src/test/groovy/com/mx/path/api/connect/http/certificate/MutualAuthProviderFactoryTest.groovy
@@ -1,8 +1,8 @@
-package com.mx.path.api.connect.http.certificates
+package com.mx.path.api.connect.http.certificate
 
-import com.mx.path.connect.http.certificates.FieldSettingsValidationError
-import com.mx.path.connect.http.certificates.MutualAuthProviderFactory
-import com.mx.path.connect.http.certificates.MutualAuthProviderKeystore
+import com.mx.path.connect.http.certificate.FieldSettingsValidationError
+import com.mx.path.connect.http.certificate.MutualAuthProviderFactory
+import com.mx.path.connect.http.certificate.MutualAuthProviderKeystore
 import com.mx.path.core.common.connect.ConnectionSettings
 import com.mx.path.core.common.connect.RequestFilter
 

--- a/upgrades/v2/core-2-upgrade.sh
+++ b/upgrades/v2/core-2-upgrade.sh
@@ -85,6 +85,7 @@ function process_file {
     "com\.mx\.path\.model\.context\.=com.mx.path.core.context."
     "com\.mx\.path\.utilities\.=com.mx.path.core.utility."
     "com\.mx\.path\.core\.utility\.OAuth\.=com.mx.path.core.utility.oauth."
+    "com\.mx\.path\.connect\.http\.certificates\.=com.mx.path.connect.http.certificate."
 
     "com\.mx\.path\.core\.common\.accessor\.AccessorConfiguration([^a-zA-Z])=com.mx.path.gateway.accessor.AccessorConfiguration\1"
     "com\.mx\.path\.core\.common\.accessor\.AccessorConnectionBase([^a-zA-Z])=com.mx.path.gateway.accessor.AccessorConnectionBase\1"
@@ -116,6 +117,7 @@ function process_file {
     "com\.mx\.path\.model\.context\.=com.mx.path.core.context."
     "com\.mx\.path\.utilities\.=com.mx.path.core.utility."
     "com\.mx\.path\.core\.utility\.OAuth\.=com.mx.path.core.utility.oauth."
+    "com\.mx\.path\.connect\.http\.certificates\.=com.mx.path.connect.http.certificate."
 
     "com\.mx\.path\.core\.common\.accessor\.AccessorConfiguration([^a-zA-Z]?)=com.mx.path.gateway.accessor.AccessorConfiguration\1"
     "com\.mx\.path\.core\.common\.accessor\.AccessorConnectionBase([^a-zA-Z]?)=com.mx.path.gateway.accessor.AccessorConnectionBase\1"


### PR DESCRIPTION
# Summary of Changes

Renaming com.mx.path.api.connect.http.certificates to com.mx.path.api.connect.http.certificate (missed it in previous reorganization)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
