### PR TITLE
feat: collection ordering annotation and comparator

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/collection/Order.java
+++ b/common/src/main/java/com/mx/path/core/common/collection/Order.java
@@ -1,0 +1,18 @@
+package com.mx.path.core.common.collection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that allows a class to declare it's preferred ordering in a collection.
+ *
+ * <p>Intended to be used with {@link OrderComparator}. See {@link Ordered} for constants
+ * that can be used for {@link #value()}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Order {
+  int value();
+}

--- a/common/src/main/java/com/mx/path/core/common/collection/OrderComparator.java
+++ b/common/src/main/java/com/mx/path/core/common/collection/OrderComparator.java
@@ -1,0 +1,39 @@
+package com.mx.path.core.common.collection;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+public class OrderComparator implements Comparator<Object>, Serializable {
+  /**
+   * Compare 2 arbitrary objects using {@link Order} annotation
+   *
+   * <p>Lower values will appear first in the list and same values will be unchanged, relative to each other.
+   *
+   * <p>Nulls and missing annotations will be treated as indifferent and their order will be unaffected, relative to
+   * each other.
+   *
+   * <p>See {@link Ordered} and {@link Order}
+   *
+   * @param o1 the first object to be compared.
+   * @param o2 the second object to be compared.
+   * @return -1 if o1 &lt; o2, 1 if o1 &gt; o2, 0 if o1 == o2
+   */
+  @Override
+  public int compare(Object o1, Object o2) {
+    return Integer.compare(getObjectOrder(o1), getObjectOrder(o2));
+  }
+
+  private int getObjectOrder(Object obj) {
+    if (obj == null) {
+      return Ordered.INDIFFERENT;
+    }
+
+    Order annotation = obj.getClass().getDeclaredAnnotation(Order.class);
+
+    if (annotation == null) {
+      return Ordered.INDIFFERENT;
+    }
+
+    return annotation.value();
+  }
+}

--- a/common/src/main/java/com/mx/path/core/common/collection/Ordered.java
+++ b/common/src/main/java/com/mx/path/core/common/collection/Ordered.java
@@ -1,0 +1,7 @@
+package com.mx.path.core.common.collection;
+
+public class Ordered {
+  public static final int FIRST = Integer.MIN_VALUE;
+  public static final int INDIFFERENT = 0;
+  public static final int LAST = Integer.MAX_VALUE;
+}

--- a/common/src/test/groovy/com/mx/path/core/common/collection/OrderComparatorTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/collection/OrderComparatorTest.groovy
@@ -1,0 +1,139 @@
+package com.mx.path.core.common.collection
+
+import com.mx.testing.collection.OrderedFirst
+import com.mx.testing.collection.OrderedIndifferent1
+import com.mx.testing.collection.OrderedIndifferent2
+import com.mx.testing.collection.OrderedLast
+import com.mx.testing.collection.OrderedUnspecified
+
+import spock.lang.Specification
+
+class OrderComparatorTest extends Specification {
+
+  def "first and last"() {
+    given:
+    def input = [
+      new OrderedLast(),
+      new OrderedFirst()
+    ]
+
+    when:
+    input.sort(new OrderComparator())
+
+    then:
+    input[0].class == OrderedFirst
+    input[1].class == OrderedLast
+  }
+
+  def "multiple first does not affect order"() {
+    given:
+    def first1 = new OrderedFirst()
+    def first2 = new OrderedFirst()
+    def first3 = new OrderedFirst()
+    def input = [first2, first3, first1]
+
+    when:
+    input.sort(new OrderComparator())
+
+    then:
+    input[0] == first2
+    input[1] == first3
+    input[2] == first1
+  }
+
+  def "multiple last does not affect order"() {
+    given:
+    def last1 = new OrderedLast()
+    def last2 = new OrderedLast()
+    def last3 = new OrderedLast()
+    def input = [last2, last3, last1]
+
+    when:
+    input.sort(new OrderComparator())
+
+    then:
+    input[0] == last2
+    input[1] == last3
+    input[2] == last1
+  }
+
+  def "indifferent does not affect order"() {
+    given:
+    def indifferent1 = new OrderedIndifferent1()
+    def indifferent2 = new OrderedIndifferent2()
+    def indifferent3 = new OrderedIndifferent1()
+    def input = [
+      indifferent2,
+      null,
+      indifferent3,
+      null,
+      indifferent1
+    ]
+
+    when:
+    input.sort(new OrderComparator())
+
+    then:
+    input[0] == indifferent2
+    input[1] == null
+    input[2] == indifferent3
+    input[3] == null
+    input[4] == indifferent1
+  }
+
+  def "simple sort"() {
+    given:
+    def first1 = new OrderedFirst()
+    def indifferent1 = new OrderedIndifferent1()
+    def last1 = new OrderedLast()
+
+    def input = [last1, indifferent1, first1]
+
+    when:
+    input.sort(new OrderComparator())
+
+    then:
+    verifyAll {
+      input[0] == first1
+      input[1] == indifferent1
+      input[2] == last1
+    }
+  }
+
+  def "sorts"() {
+    given:
+    def first1 = new OrderedFirst()
+    def first2 = new OrderedFirst()
+    def indifferent1 = new OrderedIndifferent1()
+    def indifferent2 = new OrderedIndifferent2()
+    def unspecified = new OrderedUnspecified()
+    def last1 = new OrderedLast()
+    def last2 = new OrderedLast()
+
+    def input = [
+      indifferent2,
+      first1,
+      last2,
+      unspecified,
+      last1,
+      indifferent1,
+      null,
+      first2
+    ]
+
+    when:
+    input.sort(new OrderComparator())
+
+    then:
+    verifyAll {
+      input[0] == first1
+      input[1] == first2
+      input[2] == indifferent2
+      input[3] == unspecified
+      input[4] == indifferent1
+      input[5] == null
+      input[6] == last2
+      input[7] == last1
+    }
+  }
+}

--- a/common/src/test/java/com/mx/testing/collection/OrderedFirst.java
+++ b/common/src/test/java/com/mx/testing/collection/OrderedFirst.java
@@ -1,0 +1,8 @@
+package com.mx.testing.collection;
+
+import com.mx.path.core.common.collection.Order;
+import com.mx.path.core.common.collection.Ordered;
+
+@Order(Ordered.FIRST)
+public class OrderedFirst {
+}

--- a/common/src/test/java/com/mx/testing/collection/OrderedIndifferent1.java
+++ b/common/src/test/java/com/mx/testing/collection/OrderedIndifferent1.java
@@ -1,0 +1,8 @@
+package com.mx.testing.collection;
+
+import com.mx.path.core.common.collection.Order;
+import com.mx.path.core.common.collection.Ordered;
+
+@Order(Ordered.INDIFFERENT)
+public class OrderedIndifferent1 {
+}

--- a/common/src/test/java/com/mx/testing/collection/OrderedIndifferent2.java
+++ b/common/src/test/java/com/mx/testing/collection/OrderedIndifferent2.java
@@ -1,0 +1,8 @@
+package com.mx.testing.collection;
+
+import com.mx.path.core.common.collection.Order;
+import com.mx.path.core.common.collection.Ordered;
+
+@Order(Ordered.INDIFFERENT)
+public class OrderedIndifferent2 {
+}

--- a/common/src/test/java/com/mx/testing/collection/OrderedLast.java
+++ b/common/src/test/java/com/mx/testing/collection/OrderedLast.java
@@ -1,0 +1,8 @@
+package com.mx.testing.collection;
+
+import com.mx.path.core.common.collection.Order;
+import com.mx.path.core.common.collection.Ordered;
+
+@Order(Ordered.LAST)
+public class OrderedLast {
+}

--- a/common/src/test/java/com/mx/testing/collection/OrderedUnspecified.java
+++ b/common/src/test/java/com/mx/testing/collection/OrderedUnspecified.java
@@ -1,0 +1,4 @@
+package com.mx.testing.collection;
+
+public class OrderedUnspecified {
+}

--- a/gateway/src/main/java/com/mx/path/gateway/configuration/BehaviorStackConfigurator.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/BehaviorStackConfigurator.java
@@ -1,6 +1,7 @@
 package com.mx.path.gateway.configuration;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import lombok.Getter;
@@ -8,12 +9,15 @@ import lombok.Setter;
 
 import com.mx.path.core.common.collection.ObjectArray;
 import com.mx.path.core.common.collection.ObjectMap;
+import com.mx.path.core.common.collection.OrderComparator;
 import com.mx.path.gateway.behavior.GatewayBehavior;
 
 public class BehaviorStackConfigurator {
 
   private final ConfigurationState state;
   private final GatewayObjectConfigurator gatewayObjectConfigurator;
+
+  private final Comparator<Object> comparator = new OrderComparator();
 
   @Getter
   @Setter
@@ -38,8 +42,8 @@ public class BehaviorStackConfigurator {
         behaviorsMap.addAll(map.getArray("behaviors"));
       }
 
-      // todo: Add behavior priority sorting
       addBehaviors(behaviors, behaviorsMap, clientId);
+      behaviors.sort(comparator);
 
       return behaviors;
     });


### PR DESCRIPTION
## Summary

Adding a collection ordering annotation (`Order`) and comparator (`OrderComparator`). These are general purpose, but are being added to support behavior ordering.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
