### PR TITLE
fix: handle null ObjectMap in ConfigurationBinder

### DIFF
--- a/gateway/src/main/java/com/mx/path/gateway/configuration/ConfigurationBinder.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/ConfigurationBinder.java
@@ -194,6 +194,10 @@ public class ConfigurationBinder {
   private void populateFields(Object obj, ObjectMap configurationMap) {
     Map<String, Annotations.AnnotatedField<ConfigurationField>> configurationFieldMap = prepareConfigurationObjectFields(obj);
 
+    if (configurationMap == null) {
+      configurationMap = new ObjectMap();
+    }
+
     configurationMap.forEach((fieldName, fieldValue) -> {
       Annotations.AnnotatedField<ConfigurationField> configurationAnnotatedField = configurationFieldMap.get(fieldName);
 

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfigurationBinderTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfigurationBinderTest.groovy
@@ -44,6 +44,18 @@ class ConfigurationBinderTest extends Specification {
       initialized
       validated
     }
+
+    when: "given null configuration map"
+    configurationObj = new BasicConfigurationObj()
+    subject.configure(configurationObj, null)
+
+    then: "takes defaults"
+    verifyAll (configurationObj) {
+      getKey1() == null
+      getKey2() == null
+      initialized
+      validated
+    }
   }
 
   def "build creates and binds attributes to existing object"() {
@@ -59,6 +71,17 @@ class ConfigurationBinderTest extends Specification {
       getClientId() == "client1"
       getKey1() == "value1"
       getKey2() == 12
+      initialized
+      validated
+    }
+
+    when: "given null configuration map"
+    configurationObj = subject.build(BasicConfigurationObj.class, null)
+
+    then: "takes defaults"
+    verifyAll (configurationObj) {
+      getKey1() == null
+      getKey2() == null
       initialized
       validated
     }
@@ -262,7 +285,7 @@ class ConfigurationBinderTest extends Specification {
     result.list.size() == 1
   }
 
-  def "reports correction name when missing field"() {
+  def "reports correct name when missing field"() {
     given: "configuration missing class field"
     def configurationMap = new ObjectMap()
     state.pushLevel("ConfigurationWithChangedName")
@@ -275,7 +298,7 @@ class ConfigurationBinderTest extends Specification {
     ex.message == "Value required on class at ConfigurationWithChangedName"
   }
 
-  def "reports correction name when missing field blank"() {
+  def "reports correct name when missing field blank"() {
     given: "configuration missing class field"
     def configurationMap = new ObjectMap()
     state.pushLevel("ConfigurationWithChangedName")


### PR DESCRIPTION
# Summary

If an @Configuration annotation is provided in the constructor of any gateway object, the `configurations` hash is expected even if all defaults are desired. A null reference exception is thrown if no `configurations` node if given. This makes the `configurations` node optional. The validation will still occur, so if a required value is missing, initialization will still fail.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
