### PR TITLE
fix(mutual_auth)!: replace use of ConnectionSettings hashcode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ allprojects {
   }
 }
 
-
 subprojects {
   if (it.name != platformProject) {
     apply plugin: "java-library"

--- a/common/src/main/java/com/mx/path/core/common/connect/AccessorConnectionSettings.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/AccessorConnectionSettings.java
@@ -6,7 +6,6 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import com.mx.path.core.common.collection.ObjectMap;
@@ -19,16 +18,12 @@ import com.mx.path.core.common.lang.Strings;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class AccessorConnectionSettings implements ConnectionSettings {
 
-  @EqualsAndHashCode.Include
   private String baseUrl;
-  @EqualsAndHashCode.Include
   private String certificateAlias;
   private ObjectMap configurations;
   private char[] keystorePassword;
-  @EqualsAndHashCode.Include
   private String keystorePath;
   private List<RequestFilter> baseRequestFilters;
   private boolean skipHostNameVerify;
@@ -83,5 +78,28 @@ public class AccessorConnectionSettings implements ConnectionSettings {
       ObjectMap configs = description.createMap("configurations");
       configurations.forEach(configs::put);
     }
+  }
+
+  /**
+   * Used to represent this connection's uniqueness for mutual auth
+   *
+   * <p>Only override if your class needs more uniqueness. (rare)
+   * @return Hash of baseUrl, certificateAlias, and keystorePath.
+   */
+  @SuppressWarnings("MagicNumber")
+  @Override
+  public int mutualAuthProviderHashcode() {
+    int result = 1;
+
+    Object thisBaseUrl = this.getBaseUrl();
+    result = result * 59 + (thisBaseUrl == null ? 43 : thisBaseUrl.hashCode());
+
+    Object thisCertificateAlias = this.getCertificateAlias();
+    result = result * 59 + (thisCertificateAlias == null ? 43 : thisCertificateAlias.hashCode());
+
+    Object thisKeystorePath = this.getKeystorePath();
+    result = result * 59 + (thisKeystorePath == null ? 43 : thisKeystorePath.hashCode());
+
+    return result;
   }
 }

--- a/common/src/main/java/com/mx/path/core/common/connect/ConnectionSettings.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/ConnectionSettings.java
@@ -27,6 +27,11 @@ public interface ConnectionSettings {
   char[] getKeystorePassword();
 
   /**
+   * @return hashcode representing connection uniqueness for mutual authentication settings
+   */
+  int mutualAuthProviderHashcode();
+
+  /**
    * @return list of configured request filters to be used when executing connection's requests
    */
   List<RequestFilter> getBaseRequestFilters();

--- a/common/src/test/groovy/com/mx/path/core/common/connect/AccessorConnectionSettingsTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/connect/AccessorConnectionSettingsTest.groovy
@@ -11,17 +11,17 @@ class AccessorConnectionSettingsTest extends Specification {
     settings = new AccessorConnectionSettings()
   }
 
-  def "test hashCode"() {
+  def "test mutualAuthProviderHashcode"() {
     given:
     settings.setBaseUrl("http://localhost:3001")
     settings.setCertificateAlias("certificate1")
     settings.setKeystorePath("./src/test/resources/keystore.jks")
 
     when:
-    def first = settings.hashCode()
+    def first = settings.mutualAuthProviderHashcode()
 
     then:
-    first == settings.hashCode()
+    first == settings.mutualAuthProviderHashcode()
 
     when:
     settings.setBaseUrl("http://localhost:3002")
@@ -29,7 +29,7 @@ class AccessorConnectionSettingsTest extends Specification {
     settings.setKeystorePath("./src/test/resources/keystore.jks")
 
     then:
-    first != settings.hashCode()
+    first != settings.mutualAuthProviderHashcode()
 
     when:
     settings.setBaseUrl("http://localhost:3001")
@@ -37,7 +37,7 @@ class AccessorConnectionSettingsTest extends Specification {
     settings.setKeystorePath("./src/test/resources/keystore.jks")
 
     then:
-    first != settings.hashCode()
+    first != settings.mutualAuthProviderHashcode()
 
     when:
     settings.setBaseUrl("http://localhost:3001")
@@ -45,7 +45,7 @@ class AccessorConnectionSettingsTest extends Specification {
     settings.setKeystorePath("./src/test/resources/another_keystore.jks")
 
     then:
-    first != settings.hashCode()
+    first != settings.mutualAuthProviderHashcode()
 
     when:
     settings.setBaseUrl("http://localhost:3001")
@@ -58,6 +58,6 @@ class AccessorConnectionSettingsTest extends Specification {
     settings.setConfigurations(new ObjectMap().tap { put("uncle", "bob") })
 
     then:
-    first == settings.hashCode()
+    first == settings.mutualAuthProviderHashcode()
   }
 }

--- a/common/src/test/groovy/com/mx/path/core/common/connect/RequestTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/connect/RequestTest.groovy
@@ -140,6 +140,11 @@ class RequestTest extends Specification {
     }
 
     @Override
+    int mutualAuthProviderHashcode() {
+      return 0
+    }
+
+    @Override
     List<RequestFilter> getBaseRequestFilters() {
       return null
     }

--- a/http/src/main/java/com/mx/path/connect/http/certificate/MutualAuthProviderFactory.java
+++ b/http/src/main/java/com/mx/path/connect/http/certificate/MutualAuthProviderFactory.java
@@ -8,22 +8,22 @@ import com.mx.path.core.common.connect.ConnectionSettings;
 import com.mx.path.core.common.lang.Strings;
 
 public class MutualAuthProviderFactory {
-  private static Map<ConnectionSettings, MutualAuthProvider> mutualAuthProviderInstances = new HashMap<>();
+  private static Map<Integer, MutualAuthProvider> mutualAuthProviderInstances = new HashMap<>();
 
   public static MutualAuthProvider build(ConnectionSettings settings) {
     if (settings == null || !isMutualAuthEnabled(settings)) {
       return null;
     }
 
-    if (!mutualAuthProviderInstances.containsKey(settings)) {
+    if (!mutualAuthProviderInstances.containsKey(settings.mutualAuthProviderHashcode())) {
       synchronized (MutualAuthProviderFactory.class) {
-        if (!mutualAuthProviderInstances.containsKey(settings)) {
-          mutualAuthProviderInstances.put(settings, buildProvider(settings));
+        if (!mutualAuthProviderInstances.containsKey(settings.mutualAuthProviderHashcode())) {
+          mutualAuthProviderInstances.put(settings.mutualAuthProviderHashcode(), buildProvider(settings));
         }
       }
     }
 
-    return mutualAuthProviderInstances.get(settings);
+    return mutualAuthProviderInstances.get(settings.mutualAuthProviderHashcode());
   }
 
   public static void validateSettings(ConnectionSettings settings) throws FieldSettingsValidationError {


### PR DESCRIPTION
# Summary of Changes

This replaces the use of `AccessorConnectionSettings.hashcode` with more explicit `mutualAuthProviderHashcode`. This maintains the ability to override `ConnectionSettings` uniqueness for caching of mutual auth settings, but fixes the lack of transparency of solution that used equals/hashcode.

BREAKING CHANGE:

This adds a method to `ConnectionSettings` interface.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
