### PR TITLE
feat: add support for regex pattern configuration binding

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/configuration/package-info.java
+++ b/common/src/main/java/com/mx/path/core/common/configuration/package-info.java
@@ -56,12 +56,18 @@
  *    <li>Long
  *    <li>Double
  *    <li>Enumerations (see notes)
+ *    <li>Regex Pattern (see notes)
  *    <li>Duration (see notes)
  *  </ul>
  *
  *  <p><strong>Enumerations</strong>
  *  <p>Enumerations are matched using a case-insensitive comparison with name() and toString() of the enumerations
  *  values.
+ *
+ *  <p><strong>Patterns</strong>
+ *  <p>Regular expression strings can be coerced into a {@link java.util.regex.Pattern}. Use Embedded Flag Expressions
+ *  to specify flags. See https://docs.oracle.com/javase/tutorial/essential/regex/pattern.html and javadocs for
+ *  {@link java.util.regex.Pattern} for details.
  *
  *  <p><strong>Durations</strong>
  *  <p>When dealing with time lengths, the use of Durations is preferred rather than using simple integer values. This

--- a/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
+++ b/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
@@ -5,6 +5,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import com.mx.path.core.common.configuration.ConfigurationException;
 import com.mx.path.core.common.lang.Durations;
@@ -114,6 +116,10 @@ public class Fields {
       return coerceToDuration(value);
     }
 
+    if (targetType == Pattern.class) {
+      return coerceToPattern(value);
+    }
+
     if (targetType.isEnum()) {
       return coerceToEnum(targetType, value);
     }
@@ -138,5 +144,24 @@ public class Fields {
         .filter((enumValue) -> valueStr.equalsIgnoreCase(enumValue.toString()) || valueStr.equalsIgnoreCase(enumValue.name()))
         .findFirst()
         .orElseThrow(() -> new ConfigurationException("Invalid value " + valueStr + " for enumeration " + targetType.getName()));
+  }
+
+  /**
+   * Parses String into a {@link Pattern}
+   *
+   * <p>To specify flags, use the Java embedded flag expression in the regular expression string.
+   * See https://docs.oracle.com/javase/tutorial/essential/regex/pattern.html for details.
+   *
+   * @param value regular expression
+   * @return Pattern representing provided regular expression
+   */
+  private static Pattern coerceToPattern(Object value) {
+    String valueStr = value.toString().trim();
+
+    try {
+      return Pattern.compile(valueStr);
+    } catch (PatternSyntaxException e) {
+      throw new ConfigurationException("Invalid regular expression - " + valueStr, e);
+    }
   }
 }


### PR DESCRIPTION
# Summary of Changes

This adds support for regular expressions in the configuration binder. Can declare the field as a Pattern and the string will be parsed into the Pattern.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
