### PR TITLE
Support Short, Byte, and Char types in configuration binding

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
+++ b/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
@@ -116,6 +116,10 @@ public class Fields {
       return coerceToByte(value);
     }
 
+    if (targetType == char.class || targetType == Character.class) {
+      return coerceToChar(value);
+    }
+
     if (targetType == String.class) {
       return value.toString();
     }
@@ -140,6 +144,18 @@ public class Fields {
       return Byte.parseByte(value.toString());
     } catch (NumberFormatException e) {
       throw new ConfigurationException("Invalid Byte value - " + value.toString(), e);
+    }
+  }
+
+  private static Character coerceToChar(Object value) {
+    String strValue = value.toString().trim();
+    if (strValue.length() != 1) {
+      throw new ConfigurationException("Invalid char length - " + strValue);
+    }
+    try {
+      return strValue.charAt(0);
+    } catch (NumberFormatException e) {
+      throw new ConfigurationException("Invalid Short value - " + value.toString(), e);
     }
   }
 

--- a/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
+++ b/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
@@ -108,6 +108,10 @@ public class Fields {
       return Long.valueOf(value.toString().trim());
     }
 
+    if (targetType == byte.class || targetType == Byte.class) {
+      return coerceToByte(value);
+    }
+
     if (targetType == String.class) {
       return value.toString();
     }
@@ -125,6 +129,14 @@ public class Fields {
     }
 
     return value;
+  }
+
+  private static Byte coerceToByte(Object value) {
+    try {
+      return Byte.parseByte(value.toString());
+    } catch (NumberFormatException e) {
+      throw new ConfigurationException("Invalid Byte value - " + value.toString(), e);
+    }
   }
 
   @SuppressWarnings("PMD.CyclomaticComplexity")

--- a/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
+++ b/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
@@ -108,6 +108,10 @@ public class Fields {
       return Long.valueOf(value.toString().trim());
     }
 
+    if (targetType == short.class || targetType == Short.class) {
+      return coerceToShort(value);
+    }
+
     if (targetType == byte.class || targetType == Byte.class) {
       return coerceToByte(value);
     }
@@ -174,6 +178,14 @@ public class Fields {
       return Pattern.compile(valueStr);
     } catch (PatternSyntaxException e) {
       throw new ConfigurationException("Invalid regular expression - " + valueStr, e);
+    }
+  }
+
+  private static Short coerceToShort(Object value) {
+    try {
+      return Short.parseShort(value.toString());
+    } catch (NumberFormatException e) {
+      throw new ConfigurationException("Invalid Short value - " + value.toString(), e);
     }
   }
 }

--- a/common/src/test/groovy/com/mx/path/core/common/reflection/FieldsTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/reflection/FieldsTest.groovy
@@ -33,6 +33,8 @@ class FieldsTest extends Specification {
 
     private Pattern regex
 
+    private Byte bField;
+
     def getId() {
       return this.id
     }
@@ -223,5 +225,30 @@ class FieldsTest extends Specification {
     def ex = thrown(ConfigurationException)
     ex.message == "Invalid regular expression - [a-z"
     ex.cause.getClass() == PatternSyntaxException
+  }
+
+  def "coerces Byte"() {
+    given:
+    def subject = new TestDataClass()
+
+    when:
+    Fields.setFieldValue("bField", subject, 12)
+
+    then:
+    subject.bField == 12
+
+    when:
+    Fields.setFieldValue("bField", subject, null)
+
+    then:
+    subject.bField == null
+
+    when:
+    Fields.setFieldValue("bField", subject, Byte.MAX_VALUE + 1)
+
+    then:
+    def ex = thrown(ConfigurationException)
+    ex.message == "Invalid Byte value - 128"
+    ex.cause.getClass() == NumberFormatException
   }
 }

--- a/common/src/test/groovy/com/mx/path/core/common/reflection/FieldsTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/reflection/FieldsTest.groovy
@@ -33,9 +33,11 @@ class FieldsTest extends Specification {
 
     private Pattern regex
 
-    private Byte bField;
+    private Byte cByte;
 
-    private Short sField;
+    private Short cShort;
+
+    private Character cCharacter;
 
     def getId() {
       return this.id
@@ -234,19 +236,19 @@ class FieldsTest extends Specification {
     def subject = new TestDataClass()
 
     when:
-    Fields.setFieldValue("bField", subject, 12)
+    Fields.setFieldValue("cByte", subject, 12)
 
     then:
-    subject.bField == 12
+    subject.cByte == 12
 
     when:
-    Fields.setFieldValue("bField", subject, null)
+    Fields.setFieldValue("cByte", subject, null)
 
     then:
-    subject.bField == null
+    subject.cByte == null
 
     when:
-    Fields.setFieldValue("bField", subject, Byte.MAX_VALUE + 1)
+    Fields.setFieldValue("cByte", subject, Byte.MAX_VALUE + 1)
 
     then:
     def ex = thrown(ConfigurationException)
@@ -254,24 +256,49 @@ class FieldsTest extends Specification {
     ex.cause.getClass() == NumberFormatException
   }
 
+  def "coerces Character"() {
+    given:
+    def subject = new TestDataClass()
+
+    when:
+    Fields.setFieldValue("cCharacter", subject, "p")
+
+    then:
+    subject.cCharacter == 'p'
+
+    when:
+    Fields.setFieldValue("cCharacter", subject, null)
+
+    then:
+    subject.cCharacter == null
+
+    when:
+    Fields.setFieldValue("cCharacter", subject, "p?")
+
+    then:
+    def ex = thrown(ConfigurationException)
+    ex.message == "Invalid char length - p?"
+    ex.cause == null
+  }
+
   def "coerces Short"() {
     given:
     def subject = new TestDataClass()
 
     when:
-    Fields.setFieldValue("sField", subject, 12)
+    Fields.setFieldValue("cShort", subject, 12)
 
     then:
-    subject.sField == 12
+    subject.cShort == 12
 
     when:
-    Fields.setFieldValue("sField", subject, null)
+    Fields.setFieldValue("cShort", subject, null)
 
     then:
-    subject.sField == null
+    subject.cShort == null
 
     when:
-    Fields.setFieldValue("sField", subject, Short.MAX_VALUE + 1)
+    Fields.setFieldValue("cShort", subject, Short.MAX_VALUE + 1)
 
     then:
     def ex = thrown(ConfigurationException)

--- a/common/src/test/groovy/com/mx/path/core/common/reflection/FieldsTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/reflection/FieldsTest.groovy
@@ -35,6 +35,8 @@ class FieldsTest extends Specification {
 
     private Byte bField;
 
+    private Short sField;
+
     def getId() {
       return this.id
     }
@@ -249,6 +251,31 @@ class FieldsTest extends Specification {
     then:
     def ex = thrown(ConfigurationException)
     ex.message == "Invalid Byte value - 128"
+    ex.cause.getClass() == NumberFormatException
+  }
+
+  def "coerces Short"() {
+    given:
+    def subject = new TestDataClass()
+
+    when:
+    Fields.setFieldValue("sField", subject, 12)
+
+    then:
+    subject.sField == 12
+
+    when:
+    Fields.setFieldValue("sField", subject, null)
+
+    then:
+    subject.sField == null
+
+    when:
+    Fields.setFieldValue("sField", subject, Short.MAX_VALUE + 1)
+
+    then:
+    def ex = thrown(ConfigurationException)
+    ex.message == "Invalid Short value - 32768"
     ex.cause.getClass() == NumberFormatException
   }
 }


### PR DESCRIPTION
# Summary of Changes

Adding support for Short, Byte, and Char configuration binding.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
