### PR TITLE
feat: removing requirement for AccessorConfiguration parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
   id "idea"
-  id "com.github.mxenabled.coppuccino" version "3.2.10" apply false
-  id "com.github.mxenabled.vogue" version "1.0.3"
-  id "io.freefair.lombok" version "6.6.+" apply false
+  id "com.github.mxenabled.coppuccino" version "3.+" apply false
+  id "com.github.mxenabled.vogue" version "1.+"
+  id "io.freefair.lombok" version "8.0.+" apply false
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 

--- a/gateway/src/main/java/com/mx/path/gateway/accessor/Accessor.java
+++ b/gateway/src/main/java/com/mx/path/gateway/accessor/Accessor.java
@@ -18,8 +18,6 @@ import com.mx.path.core.common.gateway.GatewayAPI;
  * Base for all accessor implementations
  *
  * <p>Provides configuration and some static utility methods
- *
- * todo: Move back to gateway after model extraction
  */
 public abstract class Accessor {
 
@@ -70,10 +68,14 @@ public abstract class Accessor {
     }).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
-  private AccessorConfiguration configuration;
+  private AccessorConfiguration accessorConfiguration;
 
+  public Accessor() {
+  }
+
+  @Deprecated
   public Accessor(AccessorConfiguration configuration) {
-    this.configuration = configuration;
+    this.accessorConfiguration = configuration;
   }
 
   /**
@@ -113,17 +115,21 @@ public abstract class Accessor {
 
   /**
    * Get configuration
+   *
    * @return
+   * @deprecated Use bound @Configuration objects
    */
+  @Deprecated
   public AccessorConfiguration getConfiguration() {
-    return configuration;
+    return accessorConfiguration;
   }
 
   /**
    * Set configuration
+   *
    * @param configuration
    */
   public void setConfiguration(AccessorConfiguration configuration) {
-    this.configuration = configuration;
+    this.accessorConfiguration = configuration;
   }
 }

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/AccessorConstructionContextTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/AccessorConstructionContextTest.groovy
@@ -4,8 +4,11 @@ import com.mx.path.core.common.collection.ObjectMap
 import com.mx.path.core.common.connect.AccessorConnectionSettings
 import com.mx.path.gateway.accessor.AccessorConfiguration
 import com.mx.testing.AccountAccessorImpl
+import com.mx.testing.AccountAccessorNoConfigImpl
 import com.mx.testing.binding.AccessorWithBoundConfiguration
 import com.mx.testing.binding.AccessorWithBoundConnections
+import com.mx.testing.binding.AccessorWithNoConfigWithBoundConfiguration
+import com.mx.testing.binding.AccessorWithNoConfigWithBoundConnections
 
 import spock.lang.Specification
 
@@ -25,6 +28,20 @@ class AccessorConstructionContextTest extends Specification {
     result.getConfiguration() == configuration
   }
 
+  def "constructs basic accessor with no configuration parameter"() {
+    given:
+    def configuration = AccessorConfiguration.builder().clientId("client1").build()
+    def subject = new AccessorConstructionContext(AccountAccessorNoConfigImpl, configuration)
+
+    when:
+    def result = subject.build()
+
+    then:
+    result != null
+    result.class == AccountAccessorNoConfigImpl
+    result.getConfiguration() == configuration
+  }
+
   def "constructs accessor with bound configuration"() {
     given:
     def configuration = AccessorConfiguration.builder().clientId("client1").configuration("key1", "value1").build()
@@ -34,6 +51,21 @@ class AccessorConstructionContextTest extends Specification {
     def result = subject.build()
 
     then:
+    result.getConfiguration() == configuration
+    result.getConfigurationObj() != null
+    result.getConfigurationObj().key1 == "value1"
+  }
+
+  def "constructs accessor with no configuration with bound configuration"() {
+    given:
+    def configuration = AccessorConfiguration.builder().clientId("client1").configuration("key1", "value1").build()
+    AccessorConstructionContext<AccessorWithNoConfigWithBoundConfiguration> subject = new AccessorConstructionContext<>(AccessorWithNoConfigWithBoundConfiguration, configuration)
+
+    when:
+    def result = subject.build()
+
+    then:
+    result.getConfiguration() == configuration
     result.getConfigurationObj() != null
     result.getConfigurationObj().key1 == "value1"
   }
@@ -72,6 +104,30 @@ class AccessorConstructionContextTest extends Specification {
     def result = subject.build()
 
     then:
+    result.getConfiguration() == configuration
+    result.getConfigs().getKey1() == "value1"
+    result.getConnection1().getBaseUrl() == "http://connection1/api"
+    result.getConnection1().getConfigs().getKey1() == "connection1Value1"
+    result.getConnection2().getBaseUrl() == "http://connection2/api"
+    result.getConnection2().getConfigs().getKey1() == "connection2Value1"
+  }
+
+  def "constructs accessor with no config with connections"() {
+    given:
+    def configuration = AccessorConfiguration.builder()
+        .clientId("client1")
+        .configuration("key1", "value1")
+        .connection("connection1", AccessorConnectionSettings.builder().baseUrl("http://connection1/api").configuration("key1", "connection1Value1").build())
+        .connection("connection2", AccessorConnectionSettings.builder().baseUrl("http://connection2/api").configuration("key1", "connection2Value1").build())
+        .build()
+
+    AccessorConstructionContext<AccessorWithNoConfigWithBoundConnections> subject = new AccessorConstructionContext<>(AccessorWithNoConfigWithBoundConnections, configuration)
+
+    when:
+    def result = subject.build()
+
+    then:
+    result.getConfiguration() == configuration
     result.getConfigs().getKey1() == "value1"
     result.getConnection1().getBaseUrl() == "http://connection1/api"
     result.getConnection1().getConfigs().getKey1() == "connection1Value1"

--- a/gateway/src/test/java/com/mx/testing/AccountAccessorNoConfigImpl.java
+++ b/gateway/src/test/java/com/mx/testing/AccountAccessorNoConfigImpl.java
@@ -1,0 +1,18 @@
+package com.mx.testing;
+
+import lombok.Setter;
+
+import com.mx.testing.accessors.AccountBaseAccessor;
+
+public class AccountAccessorNoConfigImpl extends AccountBaseAccessor {
+  @Setter
+  TransactionAccessorNoConfigImpl transactions;
+
+  public AccountAccessorNoConfigImpl() {
+    transactions = new TransactionAccessorNoConfigImpl();
+  }
+
+  public TransactionAccessorNoConfigImpl transactions() {
+    return transactions;
+  }
+}

--- a/gateway/src/test/java/com/mx/testing/TransactionAccessorNoConfigImpl.java
+++ b/gateway/src/test/java/com/mx/testing/TransactionAccessorNoConfigImpl.java
@@ -1,0 +1,8 @@
+package com.mx.testing;
+
+import com.mx.testing.accessors.TransactionBaseAccessor;
+
+public class TransactionAccessorNoConfigImpl extends TransactionBaseAccessor {
+  public TransactionAccessorNoConfigImpl() {
+  }
+}

--- a/gateway/src/test/java/com/mx/testing/accessors/AccountBaseAccessor.java
+++ b/gateway/src/test/java/com/mx/testing/accessors/AccountBaseAccessor.java
@@ -19,12 +19,16 @@ public class AccountBaseAccessor extends Accessor {
   @Getter
   private TransactionBaseAccessor transactions;
 
+  public AccountBaseAccessor() {
+  }
+
   public AccountBaseAccessor(AccessorConfiguration configuration) {
     super(configuration);
   }
 
   /**
    * Accessor for account operations
+   *
    * @return accessor
    */
   @API
@@ -38,6 +42,7 @@ public class AccountBaseAccessor extends Accessor {
 
   /**
    * Get all accounts
+   *
    * @return
    */
   @GatewayAPI
@@ -48,6 +53,7 @@ public class AccountBaseAccessor extends Accessor {
 
   /**
    * Get all accounts
+   *
    * @return
    */
   @GatewayAPI

--- a/gateway/src/test/java/com/mx/testing/accessors/TransactionBaseAccessor.java
+++ b/gateway/src/test/java/com/mx/testing/accessors/TransactionBaseAccessor.java
@@ -13,12 +13,16 @@ import com.mx.testing.model.Transaction;
 @API(description = "Test transaction accessor")
 @GatewayClass
 public class TransactionBaseAccessor extends Accessor {
+  public TransactionBaseAccessor() {
+  }
+
   public TransactionBaseAccessor(AccessorConfiguration configuration) {
     super(configuration);
   }
 
   /**
    * Get all accounts
+   *
    * @return
    */
   @GatewayAPI

--- a/gateway/src/test/java/com/mx/testing/binding/AccessorWithNoConfigWithBoundConfiguration.java
+++ b/gateway/src/test/java/com/mx/testing/binding/AccessorWithNoConfigWithBoundConfiguration.java
@@ -1,0 +1,16 @@
+package com.mx.testing.binding;
+
+import lombok.Getter;
+
+import com.mx.path.core.common.configuration.Configuration;
+import com.mx.testing.accessors.AccountBaseAccessor;
+
+public class AccessorWithNoConfigWithBoundConfiguration extends AccountBaseAccessor {
+
+  @Getter
+  private final BasicConfigurationObj configurationObj;
+
+  public AccessorWithNoConfigWithBoundConfiguration(@Configuration BasicConfigurationObj config) {
+    this.configurationObj = config;
+  }
+}

--- a/gateway/src/test/java/com/mx/testing/binding/AccessorWithNoConfigWithBoundConnections.java
+++ b/gateway/src/test/java/com/mx/testing/binding/AccessorWithNoConfigWithBoundConnections.java
@@ -1,0 +1,28 @@
+package com.mx.testing.binding;
+
+import lombok.Getter;
+
+import com.mx.path.core.common.configuration.Configuration;
+import com.mx.path.gateway.configuration.annotations.Connection;
+import com.mx.testing.accessors.AccountBaseAccessor;
+
+public class AccessorWithNoConfigWithBoundConnections extends AccountBaseAccessor {
+
+  @Getter
+  private final BasicConfigurationObj configs;
+
+  @Getter
+  private final ConnectionWithBoundConfiguration connection1;
+
+  @Getter
+  private final ConnectionWithBoundConfiguration connection2;
+
+  public AccessorWithNoConfigWithBoundConnections(
+      @Configuration BasicConfigurationObj configs,
+      @Connection("connection1") ConnectionWithBoundConfiguration connection1,
+      @Connection("connection2") ConnectionWithBoundConfiguration connection2) {
+    this.configs = configs;
+    this.connection1 = connection1;
+    this.connection2 = connection2;
+  }
+}


### PR DESCRIPTION
https://gitlab.mx.com/mx/experiences/mobile-core/core-issues/-/issues/177

This removes the requirement from Accessors to have an AccessorConfiguration typed parameter in their constructor.