### PR TITLE
feat: add slice convenience method to maps

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/collection/MultiValueMap.java
+++ b/common/src/main/java/com/mx/path/core/common/collection/MultiValueMap.java
@@ -1,11 +1,13 @@
 package com.mx.path.core.common.collection;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * A multi-value backed collection that acts like a multi-value map. This can be used interchangeably with other {@link MultiValueMappable} classes.
@@ -283,6 +285,32 @@ public class MultiValueMap<K, V> implements Map<K, List<V>>, MultiValueMappable<
   @Override
   public int size() {
     return getRawMap().size();
+  }
+
+  /**
+   * Create a new MultiValueMap containing only keys matching the provided {@link Pattern}.
+   *
+   * @param pattern {@link Pattern}
+   * @return new MultiValueMap
+   */
+  public MultiValueMap<K, V> slice(Pattern pattern) {
+    return slice(Collections.singletonList(pattern));
+  }
+
+  /**
+   * Create a new MultiValueMap containing only keys matching at least one provided {@link Pattern}.
+   *
+   * @param keyPatterns list of {@link Pattern}
+   * @return new MultiValueMap
+   */
+  public MultiValueMap<K, V> slice(Collection<Pattern> keyPatterns) {
+    MultiValueMap<K, V> result = new MultiValueMap<>();
+
+    rawMap.keySet().stream().filter((key) -> keyPatterns.stream().anyMatch((p) -> p.asPredicate().test(key.toString()))).forEach((key) -> {
+      result.put(key, get(key));
+    });
+
+    return result;
   }
 
   /**

--- a/common/src/main/java/com/mx/path/core/common/collection/SingleValueMap.java
+++ b/common/src/main/java/com/mx/path/core/common/collection/SingleValueMap.java
@@ -2,10 +2,12 @@ package com.mx.path.core.common.collection;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * A multi-value backed collection that acts like a single-value map. This can be used interchangeably with other {@link MultiValueMappable} classes.
@@ -244,6 +246,32 @@ public class SingleValueMap<K, V> implements Map<K, V>, MultiValueMappable<K, V>
   @Override
   public int size() {
     return getRawMap().size();
+  }
+
+  /**
+   * Create a new SingleValueMap containing only keys matching the provided {@link Pattern}.
+   *
+   * @param pattern {@link Pattern}
+   * @return new SingleValueMap
+   */
+  public SingleValueMap<K, V> slice(Pattern pattern) {
+    return slice(Collections.singletonList(pattern));
+  }
+
+  /**
+   * Create a new SingleValueMap containing only keys matching at least one provided {@link Pattern}.
+   *
+   * @param keyPatterns list of {@link Pattern}
+   * @return new SingleValueMap
+   */
+  public SingleValueMap<K, V> slice(Collection<Pattern> keyPatterns) {
+    SingleValueMap<K, V> result = new SingleValueMap<>();
+
+    rawMap.keySet().stream().filter((key) -> keyPatterns.stream().anyMatch((p) -> p.asPredicate().test(key.toString()))).forEach((key) -> {
+      result.put(key, get(key));
+    });
+
+    return result;
   }
 
   /**

--- a/common/src/test/groovy/com/mx/path/core/common/collection/MultiValueMapTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/collection/MultiValueMapTest.groovy
@@ -1,6 +1,8 @@
 package com.mx.path.core.common.collection
 
 
+import java.util.regex.Pattern
+
 import spock.lang.Specification
 
 class MultiValueMapTest extends Specification {
@@ -129,6 +131,34 @@ class MultiValueMapTest extends Specification {
 
     then:
     empty.size() == 0
+  }
+
+  def "slice"() {
+    given:
+    subject.add("key1", "value1")
+    subject.add("x-key1", "value1")
+    subject.add("key2", "value2")
+    subject.add("x-key2", "value2")
+
+    when:
+    def result = subject.slice(Pattern.compile("^x-"))
+
+    then:
+    result.size() == 2
+    result.keySet().contains("x-key1")
+    result.keySet().contains("x-key2")
+
+    when:
+    result = subject.slice([
+      Pattern.compile("^x-"),
+      Pattern.compile("key2")
+    ])
+
+    then:
+    result.size() == 3
+    result.keySet().contains("x-key1")
+    result.keySet().contains("key2")
+    result.keySet().contains("x-key2")
   }
 
   def "isEmpty"() {

--- a/common/src/test/groovy/com/mx/path/core/common/collection/SingleValueMapTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/collection/SingleValueMapTest.groovy
@@ -1,6 +1,8 @@
 package com.mx.path.core.common.collection
 
 
+import java.util.regex.Pattern
+
 import spock.lang.Specification
 
 class SingleValueMapTest extends Specification {
@@ -53,6 +55,34 @@ class SingleValueMapTest extends Specification {
 
     then:
     empty.size() == 0
+  }
+
+  def "slice"() {
+    given:
+    subject.put("key1", "value1")
+    subject.put("x-key1", "value1")
+    subject.put("key2", "value2")
+    subject.put("x-key2", "value2")
+
+    when:
+    def result = subject.slice(Pattern.compile("^x-"))
+
+    then:
+    result.size() == 2
+    result.keySet().contains("x-key1")
+    result.keySet().contains("x-key2")
+
+    when:
+    result = subject.slice([
+      Pattern.compile("^x-"),
+      Pattern.compile("key2")
+    ])
+
+    then:
+    result.size() == 3
+    result.keySet().contains("x-key1")
+    result.keySet().contains("key2")
+    result.keySet().contains("x-key2")
   }
 
   def "isEmpty"() {


### PR DESCRIPTION
# Summary of Changes

Adds the slice convenience method to SingleValueMap and MultiValueMap. Extracts a new map containing only the key/values matching the provided Pattern.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
