### PR TITLE
feat(configuration): allow coerced types in arrays

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
+++ b/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
@@ -89,7 +89,7 @@ public class Fields {
   }
 
   @SuppressWarnings("PMD.CyclomaticComplexity")
-  private static Object coerceValueType(Class<?> targetType, Object value) {
+  public static Object coerceValueType(Class<?> targetType, Object value) {
     if (value == null) {
       return null;
     }

--- a/gateway/src/main/java/com/mx/path/gateway/configuration/AccessorConstructionContext.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/AccessorConstructionContext.java
@@ -18,6 +18,7 @@ import com.mx.path.core.common.collection.ObjectMap;
 import com.mx.path.core.common.configuration.Configuration;
 import com.mx.path.core.common.connect.AccessorConnectionSettings;
 import com.mx.path.core.common.gateway.GatewayException;
+import com.mx.path.core.common.serialization.ConfigurationTypeAdapter;
 import com.mx.path.core.common.serialization.ObjectMapJsonDeserializer;
 import com.mx.path.gateway.accessor.Accessor;
 import com.mx.path.gateway.accessor.AccessorConfiguration;
@@ -108,7 +109,10 @@ public class AccessorConstructionContext<T extends Accessor> {
   }
 
   public final void describe(ObjectMap description) {
-    GsonBuilder gsonBuilder = new GsonBuilder().registerTypeAdapter(ObjectMap.class, new ObjectMapJsonDeserializer());
+    GsonBuilder gsonBuilder = new GsonBuilder()
+        .registerTypeAdapterFactory(new ConfigurationTypeAdapter.Factory())
+        .registerTypeAdapter(ObjectMap.class, new ObjectMapJsonDeserializer());
+
     Gson gson = gsonBuilder.create();
 
     getAccessorConfiguration().describe(description);

--- a/gateway/src/main/java/com/mx/path/gateway/configuration/ConfigurationBinder.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/ConfigurationBinder.java
@@ -180,6 +180,8 @@ public class ConfigurationBinder {
     } else if (configurationValue instanceof ObjectMap) {
 
       return buildObject((ObjectMap) configurationValue, annotatedField, inArray);
+    } else if (annotatedField.getElementType() != null) {
+      return Fields.coerceValueType(annotatedField.getElementType(), configurationValue);
     } else {
       return configurationValue;
     }

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfigurationBinderTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfigurationBinderTest.groovy
@@ -1,5 +1,7 @@
 package com.mx.path.gateway.configuration
 
+import java.util.regex.Pattern
+
 import com.mx.path.core.common.collection.ObjectMap
 import com.mx.testing.binding.BasicConfigurationObj
 import com.mx.testing.binding.ConfigurationWithChangedFieldName
@@ -116,6 +118,28 @@ class ConfigurationBinderTest extends Specification {
     configurationObj.getArray1().size() == 2
     configurationObj.getArray1().get(0) == "item1"
     configurationObj.getArray1().get(1) == "item2"
+  }
+
+  def "binds arrays of coerced types"() {
+    given:
+    configuration.createArray("regex").tap {
+      add("^[abcd].*")
+      add("^[pqrs].*")
+    }
+
+    configuration.createArray("zoneIds").tap {
+      add("PST")
+    }
+
+    when:
+    BasicConfigurationObj configurationObj = subject.build(BasicConfigurationObj.class, configuration)
+
+    then:
+    verifyAll(configurationObj.getRegex()) {
+      size() == 2
+      get(0).pattern() == "^[abcd].*"
+      get(1).pattern() == "^[pqrs].*"
+    }
   }
 
   def "binds complex object"() {

--- a/gateway/src/test/java/com/mx/testing/binding/BasicConfigurationObj.java
+++ b/gateway/src/test/java/com/mx/testing/binding/BasicConfigurationObj.java
@@ -1,7 +1,9 @@
 package com.mx.testing.binding;
 
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import lombok.Data;
 import lombok.Getter;
@@ -46,6 +48,12 @@ public class BasicConfigurationObj implements Configurable {
 
   @ConfigurationField(value = "deposit", elementType = HashMap.class)
   private HashMap<String, ObjectMap> deposit;
+
+  @ConfigurationField(value = "regex", elementType = Pattern.class)
+  private List<Pattern> regex;
+
+  @ConfigurationField(elementType = ZoneId.class)
+  private List<ZoneId> zoneIds;
 
   @ClientID
   private String clientId;


### PR DESCRIPTION
# Summary of Changes

Allow configuration lists to include coerced types (e.g. Pattern, ZoneId)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
