### PR TITLE
fix: allow setting of default session expiration

### DIFF
--- a/context/src/main/java/com/mx/path/core/context/Session.java
+++ b/context/src/main/java/com/mx/path/core/context/Session.java
@@ -1,5 +1,6 @@
 package com.mx.path.core.context;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -38,7 +39,9 @@ public class Session implements SessionInfo {
 
   private static Supplier<EncryptionService> encryptionServiceSupplier = new EncryptionServiceSupplier();
 
-  private static final int DEFAULT_TIMEOUT_SECONDS = 1800;
+  private static final int DEFAULT_SESSION_EXPIRATION_MINUTES = 30;
+
+  private static Duration defaultSessionExpiration = Duration.ofMinutes(DEFAULT_SESSION_EXPIRATION_MINUTES);
 
   private static Gson gson = new GsonBuilder()
       .registerTypeAdapter(XMLGregorianCalendar.class, new XMLGregorianCalendarConverter.Deserializer())
@@ -61,6 +64,10 @@ public class Session implements SessionInfo {
     }
 
     return encryptionServiceSupplier.get();
+  }
+
+  public static void setDefaultSessionExpiration(Duration sessionExpiry) {
+    defaultSessionExpiration = sessionExpiry;
   }
 
   // Singleton
@@ -174,7 +181,7 @@ public class Session implements SessionInfo {
     Session newSession = new Session();
     newSession.id = sessionId;
     newSession.startedAt = LocalDateTime.now(ZoneId.of("UTC"));
-    newSession.expiresAt = newSession.startedAt.plusSeconds(DEFAULT_TIMEOUT_SECONDS).toEpochSecond(ZoneOffset.UTC);
+    newSession.expiresAt = newSession.startedAt.plusSeconds(defaultSessionExpiration.getSeconds()).toEpochSecond(ZoneOffset.UTC);
     return newSession;
   }
 

--- a/context/src/test/groovy/com/mx/path/core/context/SessionTest.groovy
+++ b/context/src/test/groovy/com/mx/path/core/context/SessionTest.groovy
@@ -2,6 +2,8 @@ package com.mx.path.core.context
 
 import static org.mockito.Mockito.spy
 
+import java.time.Duration
+
 import com.mx.path.core.common.security.EncryptionService
 import com.mx.path.core.context.store.SessionRepository
 import com.mx.testing.HashSessionRepository
@@ -28,6 +30,7 @@ class SessionTest extends Specification {
     Session.setRepositorySupplier(null)
     Session.setEncryptionServiceSupplier(null)
     Session.clearSession()
+    Session.setDefaultSessionExpiration(Duration.ofMinutes(30))
   }
 
   def "setCurrent"() {


### PR DESCRIPTION
# Summary of Changes

This solution has major drawbacks but restores the ability to set the session expiration. This ability was lost during SDK reorganization.

Main drawback: the expiration cannot be scopes(can't be set by client or connection).

Another solution will be needed to make this fully configurable.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
