### PR TITLE
feat(session): track keys saved to session store and DEL on logout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
-version "3.7.0-rc.1" // x-release-please-version
+version "3.7.0-SNAPSHOT" // x-release-please-version
 
 def platformProject = "platform"
 def publishedProjects = [

--- a/context/src/main/java/com/mx/path/core/context/store/SessionRepositoryImpl.java
+++ b/context/src/main/java/com/mx/path/core/context/store/SessionRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.mx.path.core.context.store;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -13,15 +14,21 @@ public class SessionRepositoryImpl implements SessionRepository {
   private static final Gson GSON = new GsonBuilder().registerTypeAdapter(LocalDateTime.class, LocalDateTimeDeserializer.builder()
       .build()).create();
 
-  private Store store;
+  private final Store store;
 
   public SessionRepositoryImpl(Store store) {
     this.store = store;
   }
 
+  /**
+   * Delete session and associated data in store
+   *
+   * @param session
+   */
   @Override
   public final void delete(Session session) {
     store.delete(session.getId());
+    deleteSessionKeys(session);
   }
 
   @Override
@@ -40,6 +47,17 @@ public class SessionRepositoryImpl implements SessionRepository {
     return (json != null) ? GSON.fromJson(json, Session.class) : null;
   }
 
+  /**
+   * Keep track of all keys set using session put, sput, putObj, and sputObj
+   *
+   * <p>All of these keys will be removed when the session is removed with {@link #delete(Session)}
+   * @param session session
+   * @param key key to track
+   */
+  public final void registerSessionKey(Session session, String key) {
+    getScopedStoreSession(session).putSet("session_keys", key, session.getExpiresIn());
+  }
+
   @Override
   public final void save(Session session) {
     String json = GSON.toJson(session);
@@ -48,6 +66,7 @@ public class SessionRepositoryImpl implements SessionRepository {
 
   @Override
   public final void saveValue(Session session, String key, String value) {
+    registerSessionKey(session, key);
     getScopedStoreSession(session).put(key, value, session.getExpiresIn());
   }
 
@@ -61,8 +80,23 @@ public class SessionRepositoryImpl implements SessionRepository {
     return getScopedStoreSession(session).putIfNotExist(key, value, expiryMilliseconds);
   }
 
+  /**
+   * Deletes all tracked session keys for given session
+   *
+   * <p>Removes all keys found in "session_keys" and then removes the "session_keys" set
+   *
+   * @param session
+   */
+  private void deleteSessionKeys(Session session) {
+    Store sessionStore = getScopedStoreSession(session);
+    Set<String> keys = sessionStore.getSet("session_keys");
+    if (keys != null) {
+      keys.forEach(sessionStore::delete);
+    }
+    sessionStore.delete("session_keys");
+  }
+
   private Store getScopedStoreSession(Session session) {
     return new ScopedStoreSession(this.store, session);
   }
-
 }


### PR DESCRIPTION
# Summary of Changes

Currently, on logout (session.delete), keys set in the SessionStore are not removed (only the primary session key). This changes SessionRepositoryImpl by adding a tracking set for all keys set using `Session.current().put()|sput()|putObj()|sputObj()`. On session delete, all of the keys in the set will be removed from the store along with the primary session object.

Example of `redis-cli MONITOR` logs:

```
1692118020.292167 [0 127.0.0.1:54994] "EXPIRE" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:Session.huge" "58"
1692118020.329654 [0 127.0.0.1:54994] "SET" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9" "{\"clientId\":\"test\",\"expiresAt\":1692118078,\"deviceId\":\"device1\",\"id\":\"b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9\",\"sessionState\":\"AUTHENTICATED\",\"startedAt\":{\"time\":{\"hour\":16,\"minute\":46,\"second\":58,\"nano\":123000000},\"date\":{\"year\":2023,\"month\":8,\"day\":15}},\"userId\":\"user-1234\"}"
1692118020.330605 [0 127.0.0.1:54994] "EXPIRE" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9" "58"
1692118022.928952 [0 127.0.0.1:54994] "GET" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9"
1692118022.945780 [0 127.0.0.1:54994] "SADD" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:session_keys" "Session.accountStuff"
1692118022.946596 [0 127.0.0.1:54994] "EXPIRE" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:session_keys" "56"
1692118022.949005 [0 127.0.0.1:54994] "SET" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:Session.accountStuff" "jasypt:dfdf9f2ab667c1604fb76d1d923646df:1AeX1jIJUjzXN/fTq/M9aBbavrU9qRTn"
1692118022.949585 [0 127.0.0.1:54994] "EXPIRE" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:Session.accountStuff" "56"
1692118022.951254 [0 127.0.0.1:54994] "GET" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:Session.huge"
1692118023.080710 [0 127.0.0.1:54994] "SET" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9" "{\"clientId\":\"test\",\"expiresAt\":1692118078,\"deviceId\":\"device1\",\"id\":\"b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9\",\"sessionState\":\"AUTHENTICATED\",\"startedAt\":{\"time\":{\"hour\":16,\"minute\":46,\"second\":58,\"nano\":123000000},\"date\":{\"year\":2023,\"month\":8,\"day\":15}},\"userId\":\"user-1234\"}"
1692118023.098371 [0 127.0.0.1:54994] "EXPIRE" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9" "55"
1692118026.437592 [0 127.0.0.1:54994] "GET" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9"
1692118026.443285 [0 127.0.0.1:54994] "SMEMBERS" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:session_keys"
1692118026.450460 [0 127.0.0.1:54994] "DEL" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:Session.huge"
1692118026.452928 [0 127.0.0.1:54994] "DEL" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:Session.junk"
1692118026.453820 [0 127.0.0.1:54994] "DEL" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:Session.accountStuff"
1692118026.454611 [0 127.0.0.1:54994] "DEL" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9:session_keys"
1692118026.455227 [0 127.0.0.1:54994] "DEL" "b40ca95b-3f5d-4fa3-82c5-c005fe2e08f9"
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
