### PR TITLE
fix: correct ambiguous model namespaing in generated gateways

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/accessor/API.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/API.java
@@ -17,4 +17,6 @@ public @interface API {
   String notes() default "";
 
   String specificationUrl() default "";
+
+  String version() default "";
 }

--- a/gateway-generator/src/main/java/com/mx/path/api/ApiMethod.java
+++ b/gateway-generator/src/main/java/com/mx/path/api/ApiMethod.java
@@ -35,14 +35,6 @@ public class ApiMethod {
     return Arrays.asList(method.getParameters());
   }
 
-  public final String getParameterizedReturnType() {
-    if (isListOp()) {
-      return typeAsClass(unwrappedReturnType()).getSimpleName() + ".ofClass(" + typeAsClass(getModel()).getSimpleName() + ".class)";
-    }
-
-    return typeAsClass(getModel()).getSimpleName() + ".class";
-  }
-
   public final boolean isValid() {
     if (method.getReturnType() != AccessorResponse.class) {
       return false;

--- a/gateway-generator/src/main/java/com/mx/path/api/GatewayGenerator.java
+++ b/gateway-generator/src/main/java/com/mx/path/api/GatewayGenerator.java
@@ -12,6 +12,7 @@ import javax.lang.model.element.TypeElement;
 import lombok.experimental.SuperBuilder;
 
 import com.mx.path.core.common.collection.ObjectMap;
+import com.mx.path.core.common.model.ModelList;
 import com.mx.path.gateway.configuration.RootGateway;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
@@ -147,7 +148,11 @@ public class GatewayGenerator {
           .addStatement("      afterAccessor(root(), accessor, gatewayRequestContext)")
           .addStatement("    }})");
 
-      methodBuilder.addStatement("  result.set(($T) executeBehaviorStack($L, gatewayRequestContext, terminatingBehavior))", method.getGenericReturnType(), method.getParameterizedReturnType());
+      if (method.isListOp()) {
+        methodBuilder.addStatement("  result.set(($T) executeBehaviorStack($T.ofClass($T.class), gatewayRequestContext, terminatingBehavior))", method.getGenericReturnType(), ModelList.class, method.getModel());
+      } else {
+        methodBuilder.addStatement("  result.set(($T) executeBehaviorStack($T.class, gatewayRequestContext, terminatingBehavior))", method.getGenericReturnType(), method.getModel());
+      }
 
       methodBuilder.addStatement("})")
           .endControlFlow("finally {\n\tif (originalRequestContext != null) {\n\t\toriginalRequestContext.register();\n\t}\n}")

--- a/gateway-generator/src/test/groovy/com/mx/path/api/ApiMethodTest.groovy
+++ b/gateway-generator/src/test/groovy/com/mx/path/api/ApiMethodTest.groovy
@@ -83,13 +83,4 @@ class ApiMethodTest extends Specification {
     invalidReturnType.getName() == "invalidReturnType"
     invalidReturnListType.getName() == "invalidReturnListType"
   }
-
-  def "getParameterizedReturnType"() {
-    when:
-    true
-
-    then:
-    get.getParameterizedReturnType() == "Account.class"
-    list.getParameterizedReturnType() == "TestMdxList.ofClass(Account.class)"
-  }
 }

--- a/test-models/src/main/java/com/mx/testing/accessors/AccountBaseAccessor.java
+++ b/test-models/src/main/java/com/mx/testing/accessors/AccountBaseAccessor.java
@@ -8,6 +8,7 @@ import com.mx.path.core.common.accessor.AccessorMethodNotImplementedException;
 import com.mx.path.core.common.gateway.GatewayAPI;
 import com.mx.path.core.common.gateway.GatewayClass;
 import com.mx.path.core.common.model.ModelList;
+import com.mx.path.core.common.remote.RemoteOperation;
 import com.mx.path.gateway.accessor.Accessor;
 import com.mx.path.gateway.accessor.AccessorConfiguration;
 import com.mx.path.gateway.accessor.AccessorResponse;
@@ -45,6 +46,17 @@ public class AccountBaseAccessor extends Accessor {
   @GatewayAPI
   @API(description = "Get all user's account")
   public AccessorResponse<ModelList<Account>> list() {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Get all accounts
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Get all user's account", version = "20240101")
+  @RemoteOperation("list20240101")
+  public AccessorResponse<ModelList<com.mx.testing.models.v20240101.Account>> list(boolean includeDeleted) {
     throw new AccessorMethodNotImplementedException();
   }
 

--- a/test-models/src/main/java/com/mx/testing/models/v20240101/Account.java
+++ b/test-models/src/main/java/com/mx/testing/models/v20240101/Account.java
@@ -1,0 +1,13 @@
+package com.mx.testing.models.v20240101;
+
+import lombok.Data;
+
+import com.mx.path.core.common.model.ModelBase;
+
+@Data
+public class Account extends ModelBase<Account> {
+  private String id;
+  private String description;
+  private String accountType;
+  private Double balance;
+}


### PR DESCRIPTION
# Summary of Changes

This fixes a problem that occurs when there are 2 classes with the same name in different packages. Brings the logic out of ApiMethod and into GatewayGenerator so that JavaPoet can be used to determine the right package imports.

Also, adds version attribute to the `@API` annotation.
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
