### PR TITLE
fix: fix ambiguous cast of incoming object in gateway methods

### DIFF
--- a/gateway-generator/src/main/java/com/mx/path/api/GatewayGenerator.java
+++ b/gateway-generator/src/main/java/com/mx/path/api/GatewayGenerator.java
@@ -106,8 +106,7 @@ public class GatewayGenerator {
       }).collect(Collectors.toList());
 
       String parameterPasser = method.getParameters().stream().map(p -> {
-
-        return "(" + p.getType().getSimpleName() + ") req.getParams().get(\"" + p.getName() + "\")";
+        return "(" + p.getType().getCanonicalName() + ") req.getParams().get(\"" + p.getName() + "\")";
       }).collect(Collectors.joining(",")).trim();
 
       MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(method.getName())

--- a/test-gateways/src/test/groovy/com/mx/gateway/GatewayMethodSpec.groovy
+++ b/test-gateways/src/test/groovy/com/mx/gateway/GatewayMethodSpec.groovy
@@ -1,0 +1,55 @@
+package com.mx.gateway
+
+
+import com.mx.testing.AccountAccessorImpl
+import com.mx.testing.BaseAccessorImpl
+import com.mx.testing.gateway.api.AccountGateway
+import com.mx.testing.model.Account
+
+import spock.lang.Specification
+
+/**
+ * These tests are intended to check that the internals of the generated gateway methods work correctly and don't
+ * encounter any casting issues.
+ */
+class GatewayMethodSpec extends Specification {
+  AccountGateway subject
+
+  def setup() {
+    def baseAccessor = new BaseAccessorImpl(null)
+    baseAccessor.setAccounts(new AccountAccessorImpl(null))
+    subject = AccountGateway.builder().baseAccessor(baseAccessor).build()
+  }
+
+  def "invocation of list type"() {
+    when:
+    def result = subject.get20240101("123")
+
+    then:
+    result != null
+    result.getResult() instanceof com.mx.testing.models.v20240101.Account
+
+    when:
+    result = subject.get("123")
+
+    then:
+    result != null
+    result.getResult() instanceof Account
+  }
+
+  def "invoke create"() {
+    when:
+    def result = subject.create(new com.mx.testing.models.v20240101.Account())
+
+    then:
+    result != null
+    result.getResult() instanceof com.mx.testing.models.v20240101.Account
+
+    when:
+    result = subject.create(new Account())
+
+    then:
+    result != null
+    result.getResult() instanceof Account
+  }
+}

--- a/test-gateways/src/test/java/com/mx/testing/AccountAccessorImpl.java
+++ b/test-gateways/src/test/java/com/mx/testing/AccountAccessorImpl.java
@@ -28,4 +28,20 @@ public class AccountAccessorImpl extends AccountBaseAccessor {
     Account account = new Account();
     return AccessorResponse.<Account>builder().result(account).status(PathResponseStatus.OK).build();
   }
+
+  @Override
+  public AccessorResponse<com.mx.testing.models.v20240101.Account> get20240101(String id) {
+    com.mx.testing.models.v20240101.Account account = new com.mx.testing.models.v20240101.Account();
+    return AccessorResponse.<com.mx.testing.models.v20240101.Account>builder().result(account).status(PathResponseStatus.OK).build();
+  }
+
+  @Override
+  public AccessorResponse<Account> create(Account account) {
+    return AccessorResponse.<Account>builder().result(account).status(PathResponseStatus.OK).build();
+  }
+
+  @Override
+  public AccessorResponse<com.mx.testing.models.v20240101.Account> create(com.mx.testing.models.v20240101.Account account) {
+    return AccessorResponse.<com.mx.testing.models.v20240101.Account>builder().result(account).status(PathResponseStatus.OK).build();
+  }
 }

--- a/test-models/src/main/java/com/mx/testing/accessors/AccountBaseAccessor.java
+++ b/test-models/src/main/java/com/mx/testing/accessors/AccountBaseAccessor.java
@@ -69,4 +69,38 @@ public class AccountBaseAccessor extends Accessor {
   public AccessorResponse<Account> get(String id) {
     throw new AccessorMethodNotImplementedException();
   }
+
+  /**
+   * Get account by id
+   * @param id
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Get user's account by account", version = "20240101")
+  public AccessorResponse<com.mx.testing.models.v20240101.Account> get20240101(String id) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Create account
+   * @param account
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Create account")
+  public AccessorResponse<Account> create(Account account) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Create account
+   * @param account
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Create account", version = "20240101")
+  @RemoteOperation("create20240101")
+  public AccessorResponse<com.mx.testing.models.v20240101.Account> create(com.mx.testing.models.v20240101.Account account) {
+    throw new AccessorMethodNotImplementedException();
+  }
 }


### PR DESCRIPTION
# Summary of Changes

The cast uses the simple name of the class. This won't work if there are multiple classes with the same name. Needs to use the canonical name. Adding some tests to check the internals of the generated gateway methods.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
