### PR TITLE
feat: add new PathRequestException flag and header to indicate internal errors

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/accessor/AccessorMethodNotImplementedException.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/AccessorMethodNotImplementedException.java
@@ -10,6 +10,7 @@ import com.mx.path.core.common.exception.PathRequestException;
 public class AccessorMethodNotImplementedException extends AccessorSystemException {
   public AccessorMethodNotImplementedException() {
     super("Method not implemented");
+    setInternal(true);
     setReport(false);
     setStatus(PathResponseStatus.NOT_IMPLEMENTED);
   }

--- a/common/src/main/java/com/mx/path/core/common/accessor/RequestPayloadException.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/RequestPayloadException.java
@@ -10,11 +10,13 @@ import com.mx.path.core.common.exception.PathRequestException;
 public class RequestPayloadException extends AccessorSystemException {
   public RequestPayloadException(String message) {
     super(message);
+    setInternal(true);
     setReport(true);
   }
 
   public RequestPayloadException(String message, Throwable cause) {
     super(message, cause);
+    setInternal(true);
     setReport(true);
   }
 }

--- a/common/src/main/java/com/mx/path/core/common/accessor/ResponsePayloadException.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/ResponsePayloadException.java
@@ -10,11 +10,13 @@ import com.mx.path.core.common.exception.PathRequestException;
 public class ResponsePayloadException extends AccessorSystemException {
   public ResponsePayloadException(String message) {
     super(message);
+    setInternal(true);
     setReport(true);
   }
 
   public ResponsePayloadException(String message, Throwable cause) {
     super(message, cause);
+    setInternal(true);
     setReport(true);
   }
 }

--- a/common/src/main/java/com/mx/path/core/common/connect/CircuitOpenException.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/CircuitOpenException.java
@@ -10,5 +10,6 @@ import com.mx.path.core.common.exception.PathRequestException;
 public class CircuitOpenException extends ServiceUnavailableException {
   public CircuitOpenException(String message, Throwable cause) {
     super(message, cause);
+    setInternal(true);
   }
 }

--- a/common/src/main/java/com/mx/path/core/common/connect/TooManyRequestsException.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/TooManyRequestsException.java
@@ -15,6 +15,7 @@ public class TooManyRequestsException extends ConnectException {
   public TooManyRequestsException(String message, Throwable cause) {
     super(message, cause);
     setCode(String.valueOf(PathResponseStatus.TOO_MANY_REQUESTS.value()));
+    setInternal(true);
     setReport(false);
     setStatus(PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
   }

--- a/common/src/main/java/com/mx/path/core/common/exception/PathRequestException.java
+++ b/common/src/main/java/com/mx/path/core/common/exception/PathRequestException.java
@@ -63,7 +63,7 @@ import com.mx.path.core.common.messaging.MessageError;
  *   {@link PathRequestExceptionWrapper} - Wraps a cause so that other attributes can be added. This exception's cause should be inspected.
  * </pre>
  *
- * <p>Each exception sets its own default Report and Status attributes. Most have constructors that allow setting
+ * <p>Each exception sets its own default Report, IsInternal, and Status attributes. Most have constructors that allow setting
  * fields common for their type. {@link PathRequestException} provides fluent setters for all attributes that will
  * allow defaults to be overridden or additional attributes to be set.
  *
@@ -90,8 +90,14 @@ public abstract class PathRequestException extends RuntimeException {
   @Setter
   private String errorTitle;
 
-  @Getter
   private final Map<String, String> headers = new LinkedHashMap<>();
+
+  /**
+   * Indicates whether this exception is internal to the system or occurred upstream
+   */
+  @Getter
+  @Setter
+  private boolean internal = false;
 
   @Setter
   private String message = "Unknown error";
@@ -129,6 +135,16 @@ public abstract class PathRequestException extends RuntimeException {
     setMessage(message);
   }
 
+  public final Map<String, String> getHeaders() {
+    if (internal) {
+      headers.put("X-Internal-Error", "true");
+    } else {
+      headers.remove("X-Internal-Error");
+    }
+
+    return headers;
+  }
+
   /**
    * Set message
    *
@@ -147,16 +163,18 @@ public abstract class PathRequestException extends RuntimeException {
    * @param newCode - String api error code
    * @return - AccessorException with newCode
    */
-  public final PathRequestException withCode(String newCode) {
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withCode(String newCode) {
     setCode(newCode);
 
-    return this;
+    return (T) this;
   }
 
-  public final PathRequestException withErrorTitle(String newErrorTitle) {
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withErrorTitle(String newErrorTitle) {
     setErrorTitle(newErrorTitle);
 
-    return this;
+    return (T) this;
   }
 
   /**
@@ -166,10 +184,18 @@ public abstract class PathRequestException extends RuntimeException {
    * @param value
    * @return
    */
-  public final PathRequestException withHeader(String name, String value) {
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withHeader(String name, String value) {
     this.headers.put(name, value);
 
-    return this;
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withIsInternal(boolean isInternal) {
+    this.internal = isInternal;
+
+    return (T) this;
   }
 
   /**
@@ -178,10 +204,11 @@ public abstract class PathRequestException extends RuntimeException {
    * @param newMessage
    * @return
    */
-  public final PathRequestException withMessage(String newMessage) {
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withMessage(String newMessage) {
     this.setMessage(newMessage);
 
-    return this;
+    return (T) this;
   }
 
   /**
@@ -190,28 +217,32 @@ public abstract class PathRequestException extends RuntimeException {
    * @param newReason - String newReason for exception (for userMessage)
    * @return - AccessorException with newReason
    */
-  public final PathRequestException withReason(String newReason) {
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withReason(String newReason) {
     this.setReason(newReason);
 
-    return this;
+    return (T) this;
   }
 
-  public final PathRequestException withReport(boolean shouldReport) {
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withReport(boolean shouldReport) {
     this.setReport(shouldReport);
 
-    return this;
+    return (T) this;
   }
 
-  public final PathRequestException withStatus(PathResponseStatus newStatus) {
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withStatus(PathResponseStatus newStatus) {
     this.setStatus(newStatus);
 
-    return this;
+    return (T) this;
   }
 
-  public final PathRequestException withUserMessage(String newUserMessage) {
+  @SuppressWarnings("unchecked")
+  public final <T extends PathRequestException> T withUserMessage(String newUserMessage) {
     this.setUserMessage(newUserMessage);
 
-    return this;
+    return (T) this;
   }
 
   /**

--- a/common/src/main/java/com/mx/path/core/common/facility/FacilityException.java
+++ b/common/src/main/java/com/mx/path/core/common/facility/FacilityException.java
@@ -11,12 +11,14 @@ import com.mx.path.core.common.exception.PathRequestException;
 public class FacilityException extends PathRequestException {
   public FacilityException(String message) {
     super(message);
+    setInternal(true);
     setReport(true);
     setStatus(PathResponseStatus.INTERNAL_ERROR);
   }
 
   public FacilityException(String message, Throwable cause) {
     super(message, cause);
+    setInternal(true);
     setReport(true);
     setStatus(PathResponseStatus.INTERNAL_ERROR);
   }

--- a/common/src/main/java/com/mx/path/core/common/gateway/BehaviorException.java
+++ b/common/src/main/java/com/mx/path/core/common/gateway/BehaviorException.java
@@ -11,12 +11,14 @@ import com.mx.path.core.common.exception.PathRequestException;
 public class BehaviorException extends GatewayException {
   public BehaviorException(String message) {
     super(message);
+    setInternal(true);
     setReport(true);
     setStatus(PathResponseStatus.INTERNAL_ERROR);
   }
 
   public BehaviorException(String message, Throwable cause) {
     super(message, cause);
+    setInternal(true);
     setReport(true);
     setStatus(PathResponseStatus.INTERNAL_ERROR);
   }

--- a/common/src/test/groovy/com/mx/path/core/common/exception/PathRequestExceptionTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/exception/PathRequestExceptionTest.groovy
@@ -1,6 +1,5 @@
 package com.mx.path.core.common.exception
 
-
 import com.mx.path.core.common.accessor.PathResponseStatus
 
 import spock.lang.Specification
@@ -33,6 +32,7 @@ class PathRequestExceptionTest extends Specification {
     verifyAll(subject) {
       getMessage() == "Unknown error"
       getCause() == null
+      !isInternal()
       getStatus() == PathResponseStatus.INTERNAL_ERROR
       shouldReport()
     }
@@ -44,6 +44,7 @@ class PathRequestExceptionTest extends Specification {
     verifyAll(subject) {
       getMessage() == "Original message"
       getCause() == null
+      !isInternal()
       getStatus() == PathResponseStatus.INTERNAL_ERROR
       shouldReport()
     }
@@ -56,6 +57,7 @@ class PathRequestExceptionTest extends Specification {
     verifyAll(subject) {
       getMessage() == "Unknown error"
       getCause() == cause
+      !isInternal()
       getStatus() == PathResponseStatus.INTERNAL_ERROR
       shouldReport()
     }
@@ -68,6 +70,7 @@ class PathRequestExceptionTest extends Specification {
     verifyAll(subject) {
       getMessage() == "Original message"
       getCause() == cause
+      !isInternal()
       getStatus() == PathResponseStatus.INTERNAL_ERROR
       shouldReport()
     }
@@ -83,6 +86,7 @@ class PathRequestExceptionTest extends Specification {
       getCause() == null
       getErrorTitle() == null
       getHeaders().isEmpty()
+      !isInternal()
       getMessage() == "Unknown error"
       getReason() == null
       shouldReport()
@@ -95,6 +99,7 @@ class PathRequestExceptionTest extends Specification {
       withCode("1401")
       withErrorTitle("Error title")
       withHeader("header", "value")
+      withIsInternal(true)
       withMessage("New message")
       withReason("Because")
       withReport(false)
@@ -108,6 +113,8 @@ class PathRequestExceptionTest extends Specification {
       getCause() == null
       getErrorTitle() == "Error title"
       getHeaders().get("header") == "value"
+      getHeaders().get("X-Internal-Error") == "true"
+      isInternal()
       getMessage() == "New message"
       getReason() == "Because"
       !shouldReport()


### PR DESCRIPTION
# Summary of Changes

Adds a new flag to PathRequestException `internal` that indicates if the exception being thrown represents an internal error (as opposed to an upstream error). Setting this flag will add an additional header to the response so that the error can be handled appropriately by calling service.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
