### PR TITLE
feat: add configurable ConnectTimeout and RequestTimeout

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/connect/AccessorConnectionSettings.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/AccessorConnectionSettings.java
@@ -1,5 +1,6 @@
 package com.mx.path.core.common.connect;
 
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -20,12 +21,14 @@ import com.mx.path.core.common.lang.Strings;
 @AllArgsConstructor
 public class AccessorConnectionSettings implements ConnectionSettings {
 
+  private List<RequestFilter> baseRequestFilters;
   private String baseUrl;
   private String certificateAlias;
   private ObjectMap configurations;
+  private Duration connectTimeout;
   private char[] keystorePassword;
   private String keystorePath;
-  private List<RequestFilter> baseRequestFilters;
+  private Duration requestTimeout;
   private boolean skipHostNameVerify;
 
   public static class AccessorConnectionSettingsBuilder {
@@ -45,6 +48,16 @@ public class AccessorConnectionSettings implements ConnectionSettings {
       return this;
     }
 
+  }
+
+  @Override
+  public final Duration getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  @Override
+  public final Duration getRequestTimeout() {
+    return requestTimeout;
   }
 
   @Override

--- a/common/src/main/java/com/mx/path/core/common/connect/ConnectionSettings.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/ConnectionSettings.java
@@ -1,10 +1,19 @@
 package com.mx.path.core.common.connect;
 
+import java.time.Duration;
 import java.util.List;
 
 import com.mx.path.core.common.collection.ObjectMap;
 
 public interface ConnectionSettings {
+
+  default void describe(ObjectMap description) {
+  }
+
+  /**
+   * @return list of configured request filters to be used when executing connection's requests
+   */
+  List<RequestFilter> getBaseRequestFilters();
 
   /**
    * @return connection's base URL
@@ -17,6 +26,11 @@ public interface ConnectionSettings {
   String getCertificateAlias();
 
   /**
+   * @return connect timeout
+   */
+  Duration getConnectTimeout();
+
+  /**
    * @return path to keystore used to store certificates
    */
   String getKeystorePath();
@@ -25,6 +39,16 @@ public interface ConnectionSettings {
    * @return password used to access certificates in keystore
    */
   char[] getKeystorePassword();
+
+  /**
+   * @return request timeout
+   */
+  Duration getRequestTimeout();
+
+  /**
+   * @return true, if host name should be checked against the certificate
+   */
+  boolean getSkipHostNameVerify();
 
   /**
    * Used to represent this connection's uniqueness for mutual auth
@@ -46,18 +70,5 @@ public interface ConnectionSettings {
     result = result * 59 + (thisKeystorePath == null ? 43 : thisKeystorePath.hashCode());
 
     return result;
-  }
-
-  /**
-   * @return list of configured request filters to be used when executing connection's requests
-   */
-  List<RequestFilter> getBaseRequestFilters();
-
-  /**
-   * @return true, if host name should be checked against the certificate
-   */
-  boolean getSkipHostNameVerify();
-
-  default void describe(ObjectMap description) {
   }
 }

--- a/common/src/main/java/com/mx/path/core/common/connect/Request.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/Request.java
@@ -59,6 +59,7 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
     STRING_AND_RAW
   }
 
+  private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofMillis(30000);
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMillis(30000);
 
   // Fields
@@ -81,6 +82,9 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
   @Getter
   @Setter
   private ConnectionSettings connectionSettings;
+
+  @Setter
+  private Duration connectTimeout;
 
   @Getter
   @Setter
@@ -137,7 +141,10 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
   private long startNano = 0;
 
   @Setter
+  @Deprecated
   private Duration timeOut;
+
+  private Duration timeout;
 
   @Getter
   @Setter
@@ -190,6 +197,15 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
     return headers.get("Accept");
   }
 
+  /**
+   * @return Connect timeout in milliseconds
+   */
+  public final Duration getConnectTimeout() {
+    connectTimeout = (connectTimeout == null) ? connectionSettings.getConnectTimeout() : connectTimeout;
+    connectTimeout = (connectTimeout == null) ? DEFAULT_CONNECT_TIMEOUT : connectTimeout;
+    return connectTimeout;
+  }
+
   public final String getContentType() {
     return headers.get("Content-Type");
   }
@@ -205,8 +221,18 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
   /**
    * @return Request timeout in milliseconds
    */
+  @Deprecated
   public final Duration getRequestTimeOut() {
     return timeOut == null ? DEFAULT_REQUEST_TIMEOUT : timeOut;
+  }
+
+  /**
+   * @return Request timeout in milliseconds
+   */
+  public final Duration getRequestTimeout() {
+    timeout = (timeout == null) ? connectionSettings.getRequestTimeout() : timeout;
+    timeout = (timeout == null) ? DEFAULT_REQUEST_TIMEOUT : timeout;
+    return timeout;
   }
 
   public final String getTraceKey() {
@@ -257,6 +283,10 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
 
   public final void setHeaders(MultiValueMappable<String, String> singleValueMap) {
     this.headers = new SingleValueMap<>(singleValueMap);
+  }
+
+  public final void setTimeout(Duration timeout) {
+    this.timeout = timeout;
   }
 
   /**
@@ -311,6 +341,16 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
   @SuppressWarnings("unchecked")
   public final REQ withConnectionSettings(ConnectionSettings newConnectionSettings) {
     setConnectionSettings(newConnectionSettings);
+    return (REQ) this;
+  }
+
+  /**
+   * Connect timeout as Duration
+   * @return this
+   */
+  @SuppressWarnings("unchecked")
+  public final REQ withConnectTimeout(Duration connectionTimeout) {
+    setConnectTimeout(connectionTimeout);
     return (REQ) this;
   }
 
@@ -490,9 +530,20 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
    * Request timeout as Duration
    * @return this
    */
+  @Deprecated
   @SuppressWarnings("unchecked")
   public final REQ withTimeOut(Duration requestTimeOut) {
-    setTimeOut(requestTimeOut);
+    setTimeout(requestTimeOut);
+    return (REQ) this;
+  }
+
+  /**
+   * Request timeout as Duration
+   * @return this
+   */
+  @SuppressWarnings("unchecked")
+  public final REQ withTimeout(Duration requestTimeout) {
+    setTimeout(requestTimeout);
     return (REQ) this;
   }
 

--- a/common/src/test/groovy/com/mx/path/core/common/connect/RequestTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/connect/RequestTest.groovy
@@ -248,28 +248,8 @@ class RequestTest extends Specification {
 
   class TestMutualAuthSettings implements ConnectionSettings {
     @Override
-    String getKeystorePath() {
-      return null
-    }
-
-    @Override
-    char[] getKeystorePassword() {
-      return null
-    }
-
-    @Override
-    int mutualAuthProviderHashcode() {
-      return 0
-    }
-
-    @Override
     List<RequestFilter> getBaseRequestFilters() {
       return null
-    }
-
-    @Override
-    boolean getSkipHostNameVerify() {
-      return false
     }
 
     @Override
@@ -280,6 +260,36 @@ class RequestTest extends Specification {
     @Override
     String getCertificateAlias() {
       return null
+    }
+
+    @Override
+    Duration getConnectTimeout() {
+      return null
+    }
+
+    @Override
+    String getKeystorePath() {
+      return null
+    }
+
+    @Override
+    char[] getKeystorePassword() {
+      return null
+    }
+
+    @Override
+    Duration getRequestTimeout() {
+      return null
+    }
+
+    @Override
+    boolean getSkipHostNameVerify() {
+      return false
+    }
+
+    @Override
+    int mutualAuthProviderHashcode() {
+      return 0
     }
   }
 
@@ -297,12 +307,13 @@ class RequestTest extends Specification {
     def request = new TestRequest(filterChain)
         .withAccept("application/json")
         .withBaseUrl("https://example.com")
+        .withConnectTimeout(Duration.ofMillis((1000)))
         .withContentType("application/json")
         .withFeature(Feature.ACCOUNTS)
         .withHeader("headerKey", "headerValue")
         .withPath("/some/path")
         .withQueryStringParams(new SingleValueMap<String, String>().tap {put("key", "value")})
-        .withTimeOut(Duration.ofMillis(100))
+        .withTimeout(Duration.ofMillis(100))
 
     when: "same instance"
     def sameRequestInstance = request
@@ -321,12 +332,13 @@ class RequestTest extends Specification {
     def requestWithSameProperties = new TestRequest(filterChain)
         .withAccept("application/json")
         .withBaseUrl("https://example.com")
+        .withConnectTimeout(Duration.ofMillis((1000)))
         .withContentType("application/json")
         .withFeature(Feature.ACCOUNTS)
         .withHeader("headerKey", "headerValue")
         .withPath("/some/path")
         .withQueryStringParams(new SingleValueMap<String, String>().tap {put("key", "value")})
-        .withTimeOut(Duration.ofMillis(100))
+        .withTimeout(Duration.ofMillis(100))
 
     then:
     request.equals(requestWithSameProperties)
@@ -336,12 +348,13 @@ class RequestTest extends Specification {
     def requestWithDifferentProperties = new TestRequest(filterChain)
         .withAccept("application/json")
         .withBaseUrl("https://example.com")
+        .withConnectTimeout(Duration.ofMillis((1000)))
         .withContentType("application/json")
         .withFeature(Feature.TRANSFERS)
         .withHeader("headerKey", "headerValue2")
         .withPath("/some/other/path")
         .withQueryStringParams(new SingleValueMap<String, String>().tap {put("key", "value2")})
-        .withTimeOut(Duration.ofMillis(100))
+        .withTimeout(Duration.ofMillis(100))
 
     then:
     !request.equals(requestWithDifferentProperties)

--- a/http/src/main/java/com/mx/path/connect/http/HttpClientFilter.java
+++ b/http/src/main/java/com/mx/path/connect/http/HttpClientFilter.java
@@ -100,9 +100,9 @@ public class HttpClientFilter extends RequestFilterBase {
       // NOTE: Good writeup on timeouts: https://www.baeldung.com/httpclient-timeout
       RequestConfig requestConfig = RequestConfig
           .custom()
-          .setConnectionRequestTimeout((int) httpRequest.getRequestTimeOut().toMillis())
-          .setConnectTimeout((int) httpRequest.getRequestTimeOut().toMillis())
-          .setSocketTimeout((int) httpRequest.getRequestTimeOut().toMillis())
+          .setConnectionRequestTimeout((int) httpRequest.getRequestTimeout().toMillis())
+          .setConnectTimeout((int) httpRequest.getConnectTimeout().toMillis())
+          .setSocketTimeout((int) httpRequest.getRequestTimeout().toMillis())
           .setCookieSpec(CookieSpecs.STANDARD)
           .build();
 


### PR DESCRIPTION
# Summary of Changes

Adds ability to configure `connectTimeout` and `requestTimeout` in `AccessorConnectionSettings`.
If built Request already calls `withTimeOut`, `withTimeout` or `withConnectTimeout`, those values will be honored in place of these configured values.
If `withTimeOut` `withTimeout` or `withConnectTimeout` are not called and there is no configuration for the AccessorConnection, then the defaults will be used (30 seconds).

Fixes # MC-1709

## Public API Additions/Changes

No changes to APIs.

## Downstream Consumer Impact

No breaking changes to consumer, this is a simple add-on that will allow more configurability for connection and request timeouts at the `AccessorConnectionSettings` level.

# How Has This Been Tested?

- [ ] Manually tested on low impact service

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
