### PR TITLE
fix: drop default connect timeout to 5 seconds

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/connect/Request.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/Request.java
@@ -544,8 +544,8 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
    * @return this
    */
   @SuppressWarnings("unchecked")
-  public final REQ withRequestTimeout(Duration requestTimeout) {
-    setRequestTimeout(requestTimeout);
+  public final REQ withRequestTimeout(Duration timeout) {
+    setRequestTimeout(timeout);
     return (REQ) this;
   }
 

--- a/common/src/main/java/com/mx/path/core/common/connect/Request.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/Request.java
@@ -144,7 +144,8 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
   @Deprecated
   private Duration timeOut;
 
-  private Duration timeout;
+  @Setter
+  private Duration requestTimeout;
 
   @Getter
   @Setter
@@ -223,16 +224,16 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
    */
   @Deprecated
   public final Duration getRequestTimeOut() {
-    return timeOut == null ? DEFAULT_REQUEST_TIMEOUT : timeOut;
+    return requestTimeout == null ? DEFAULT_REQUEST_TIMEOUT : requestTimeout;
   }
 
   /**
    * @return Request timeout in milliseconds
    */
   public final Duration getRequestTimeout() {
-    timeout = (timeout == null) ? connectionSettings.getRequestTimeout() : timeout;
-    timeout = (timeout == null) ? DEFAULT_REQUEST_TIMEOUT : timeout;
-    return timeout;
+    requestTimeout = (requestTimeout == null) ? connectionSettings.getRequestTimeout() : requestTimeout;
+    requestTimeout = (requestTimeout == null) ? DEFAULT_REQUEST_TIMEOUT : requestTimeout;
+    return requestTimeout;
   }
 
   public final String getTraceKey() {
@@ -285,8 +286,9 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
     this.headers = new SingleValueMap<>(singleValueMap);
   }
 
+  @Deprecated
   public final void setTimeout(Duration timeout) {
-    this.timeout = timeout;
+    this.requestTimeout = timeout;
   }
 
   /**
@@ -533,7 +535,7 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
   @Deprecated
   @SuppressWarnings("unchecked")
   public final REQ withTimeOut(Duration requestTimeOut) {
-    setTimeout(requestTimeOut);
+    setRequestTimeout(requestTimeOut);
     return (REQ) this;
   }
 
@@ -542,8 +544,8 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
    * @return this
    */
   @SuppressWarnings("unchecked")
-  public final REQ withTimeout(Duration requestTimeout) {
-    setTimeout(requestTimeout);
+  public final REQ withRequestTimeout(Duration requestTimeout) {
+    setRequestTimeout(requestTimeout);
     return (REQ) this;
   }
 

--- a/common/src/main/java/com/mx/path/core/common/connect/Request.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/Request.java
@@ -59,7 +59,7 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
     STRING_AND_RAW
   }
 
-  private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofMillis(30000);
+  private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofMillis(5000);
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMillis(30000);
 
   // Fields

--- a/common/src/test/groovy/com/mx/path/core/common/connect/RequestTest.groovy
+++ b/common/src/test/groovy/com/mx/path/core/common/connect/RequestTest.groovy
@@ -313,7 +313,7 @@ class RequestTest extends Specification {
         .withHeader("headerKey", "headerValue")
         .withPath("/some/path")
         .withQueryStringParams(new SingleValueMap<String, String>().tap {put("key", "value")})
-        .withTimeout(Duration.ofMillis(100))
+        .withRequestTimeout(Duration.ofMillis(100))
 
     when: "same instance"
     def sameRequestInstance = request
@@ -338,7 +338,7 @@ class RequestTest extends Specification {
         .withHeader("headerKey", "headerValue")
         .withPath("/some/path")
         .withQueryStringParams(new SingleValueMap<String, String>().tap {put("key", "value")})
-        .withTimeout(Duration.ofMillis(100))
+        .withRequestTimeout(Duration.ofMillis(100))
 
     then:
     request.equals(requestWithSameProperties)
@@ -354,7 +354,7 @@ class RequestTest extends Specification {
         .withHeader("headerKey", "headerValue2")
         .withPath("/some/other/path")
         .withQueryStringParams(new SingleValueMap<String, String>().tap {put("key", "value2")})
-        .withTimeout(Duration.ofMillis(100))
+        .withRequestTimeout(Duration.ofMillis(100))
 
     then:
     !request.equals(requestWithDifferentProperties)


### PR DESCRIPTION
# Drop connect timeout default from 30 seconds to 5 seconds

Fixes # MC-1709

## Public API Additions/Changes

No outward changes

## Downstream Consumer Impact

ConnectTimeout default dropped from 30 seconds to 5 seconds

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
