### PR TITLE
feat: add after initialize method on accessor

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/accessor/AfterAccessorInitialize.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/AfterAccessorInitialize.java
@@ -1,0 +1,29 @@
+package com.mx.path.core.common.accessor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation indicates that a method should be invoked
+ * after the accessor is initialized. Methods annotated
+ * with @AfterAccessorInitialize are called automatically by the
+ * accessor configurator to perform any necessary post-initialization actions.
+ *
+ * <p>Example Usage:</p>
+ *
+ * public class MyAccessor extends Accessor {
+ *
+ *     // This method will be invoked after the MyAccessor is initialized.
+ *     #@AfterAccessorInitialize
+ *     static void afterInitialize() {
+ *         // Perform post-initialization tasks here
+ *         System.out.println("MyAccessor has been initialized!");
+ *     }
+ * }
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AfterAccessorInitialize {
+}

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/AccessorStackConfiguratorTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/AccessorStackConfiguratorTest.groovy
@@ -1,0 +1,69 @@
+package com.mx.path.gateway.configuration
+
+import static org.mockito.Mockito.mockStatic
+import static org.mockito.Mockito.times
+
+import java.lang.reflect.Method
+
+import com.mx.path.core.common.accessor.AfterAccessorInitialize
+import com.mx.path.gateway.accessor.Accessor
+
+import org.mockito.MockedStatic
+
+import spock.lang.Specification
+
+class AccessorStackConfiguratorTest extends Specification {
+
+  class MockAccessor extends Accessor {
+    @AfterAccessorInitialize
+    static void afterInitialize() {
+    }
+  }
+
+  class ChildMockAccessor extends MockAccessor {
+    @AfterAccessorInitialize
+    static void afterInitializeChild() {
+    }
+  }
+
+  AccessorStackConfigurator subject
+  static MockedStatic<MockAccessor> mockAccessor
+  static MockedStatic<ChildMockAccessor> childMockAccessor
+
+  def setup() {
+    subject = new AccessorStackConfigurator(ConfigurationState.getCurrent())
+    mockAccessor.reset()
+    childMockAccessor.reset()
+  }
+
+  def setupSpec() {
+    mockAccessor = mockStatic(MockAccessor.class)
+    childMockAccessor = mockStatic(ChildMockAccessor.class)
+  }
+
+  def cleanupSpec() {
+    mockAccessor.close()
+    childMockAccessor.close()
+  }
+
+  def "invoke afterInitializeMethods"() {
+    when:
+    Method method = subject.class.getDeclaredMethod("invokeAfterInitializeMethods", Class)
+    method.setAccessible(true)
+    method.invoke(subject, MockAccessor.class)
+
+    then:
+    mockAccessor.verify({ MockAccessor.afterInitialize() }, times(1))
+  }
+
+  def "invoke both afterInitializeMethods"() {
+    when:
+    Method method = subject.class.getDeclaredMethod("invokeAfterInitializeMethods", Class)
+    method.setAccessible(true)
+    method.invoke(subject, ChildMockAccessor.class)
+
+    then:
+    mockAccessor.verify({ MockAccessor.afterInitialize() }, times(1))
+    childMockAccessor.verify({ ChildMockAccessor.afterInitializeChild() }, times(1))
+  }
+}

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfiguratorTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfiguratorTest.groovy
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.times
 import static org.mockito.Mockito.verify
 
 import com.mx.path.gateway.Gateway
-import com.mx.testing.gateway.BaseGateway
 import com.mx.testing.gateway.TestAccountGateway
 import com.mx.testing.gateway.TestGateway
 import com.mx.testing.gateway.TestIdGateway


### PR DESCRIPTION
# Summary of Changes

Add hook method on Accessor which is called after class is built.

```java
  public class MyAccessor extends Accessor {
 
      // This method will be invoked after MyAccessor is initialized.
      @AfterAccessorInitialize
      static void afterInitialize() {
          // Perform post-initialization tasks here
          System.out.println("MyAccessor has been initialized!");
      }
 }
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
