### PR TITLE
internal error flag handled for nats timeout error

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/messaging/MessageBrokerException.java
+++ b/common/src/main/java/com/mx/path/core/common/messaging/MessageBrokerException.java
@@ -2,7 +2,9 @@ package com.mx.path.core.common.messaging;
 
 import com.mx.path.core.common.accessor.PathResponseStatus;
 import com.mx.path.core.common.exception.PathRequestException;
-
+/**
+ * All errors from NATS should be wrapped in this exception
+ */
 public class MessageBrokerException extends PathRequestException {
 
   public MessageBrokerException(String message, Throwable cause) {

--- a/common/src/main/java/com/mx/path/core/common/messaging/MessageBrokerException.java
+++ b/common/src/main/java/com/mx/path/core/common/messaging/MessageBrokerException.java
@@ -1,0 +1,14 @@
+package com.mx.path.core.common.messaging;
+
+import com.mx.path.core.common.accessor.PathResponseStatus;
+import com.mx.path.core.common.exception.PathRequestException;
+
+public class MessageBrokerException extends PathRequestException {
+
+  public MessageBrokerException(String message, Throwable cause) {
+    super(message, cause);
+    setInternal(true);
+    setReport(true);
+    setStatus(PathResponseStatus.INTERNAL_ERROR);
+  }
+}

--- a/common/src/main/java/com/mx/path/core/common/messaging/MessageBrokerException.java
+++ b/common/src/main/java/com/mx/path/core/common/messaging/MessageBrokerException.java
@@ -2,6 +2,7 @@ package com.mx.path.core.common.messaging;
 
 import com.mx.path.core.common.accessor.PathResponseStatus;
 import com.mx.path.core.common.exception.PathRequestException;
+
 /**
  * All errors from NATS should be wrapped in this exception
  */

--- a/messaging/src/main/java/com/mx/path/connect/messaging/remote/RemoteCRUDModel.java
+++ b/messaging/src/main/java/com/mx/path/connect/messaging/remote/RemoteCRUDModel.java
@@ -4,7 +4,7 @@ import com.mx.path.connect.messaging.MessageHeaders;
 import com.mx.path.connect.messaging.MessageParameters;
 import com.mx.path.connect.messaging.MessageRequest;
 import com.mx.path.connect.messaging.MessageResponse;
-import com.mx.path.core.common.facility.FacilityException;
+import com.mx.path.core.common.messaging.MessageBrokerException;
 import com.mx.path.core.common.messaging.MessageError;
 import com.mx.path.core.common.messaging.MessageStatus;
 import com.mx.path.core.common.model.ModelBase;
@@ -129,7 +129,7 @@ public class RemoteCRUDModel<T extends ModelBase<?>> extends RemoteRequester<T> 
     MessageResponse response = executeRequest(clientId, request);
 
     if (response.getStatus() != MessageStatus.SUCCESS) {
-      throw new FacilityException("Unable to create remote " + RemoteChannel.getModel(getClassOfT()) + " with status " + response.getStatus(), response.getException());
+      throw new MessageBrokerException("Unable to create remote " + RemoteChannel.getModel(getClassOfT()) + " with status " + response.getStatus(), response.getException());
     }
 
     return response.getBodyAs(getClassOfT());

--- a/messaging/src/main/java/com/mx/path/connect/messaging/remote/RemoteCRUDModel.java
+++ b/messaging/src/main/java/com/mx/path/connect/messaging/remote/RemoteCRUDModel.java
@@ -4,6 +4,7 @@ import com.mx.path.connect.messaging.MessageHeaders;
 import com.mx.path.connect.messaging.MessageParameters;
 import com.mx.path.connect.messaging.MessageRequest;
 import com.mx.path.connect.messaging.MessageResponse;
+import com.mx.path.core.common.facility.FacilityException;
 import com.mx.path.core.common.messaging.MessageError;
 import com.mx.path.core.common.messaging.MessageStatus;
 import com.mx.path.core.common.model.ModelBase;
@@ -128,7 +129,7 @@ public class RemoteCRUDModel<T extends ModelBase<?>> extends RemoteRequester<T> 
     MessageResponse response = executeRequest(clientId, request);
 
     if (response.getStatus() != MessageStatus.SUCCESS) {
-      throw new MessageError("Unable to create remote " + RemoteChannel.getModel(getClassOfT()) + " with status " + response.getStatus(), response.getStatus(), response.getException());
+      throw new FacilityException("Unable to create remote " + RemoteChannel.getModel(getClassOfT()) + " with status " + response.getStatus(), response.getException());
     }
 
     return response.getBodyAs(getClassOfT());

--- a/messaging/src/test/groovy/com/mx/path/connect/messaging/remote/RemoteCRUDModelTest.groovy
+++ b/messaging/src/test/groovy/com/mx/path/connect/messaging/remote/RemoteCRUDModelTest.groovy
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.*
 
 import com.mx.path.connect.messaging.MessageResponse
+import com.mx.path.core.common.facility.FacilityException
 import com.mx.path.core.common.messaging.MessageBroker
 import com.mx.path.core.common.messaging.MessageError
 import com.mx.path.core.common.messaging.MessageStatus
@@ -190,7 +191,6 @@ class RemoteCRUDModelTest extends Specification {
     subject.create(account)
 
     then:
-    def e = thrown(MessageError)
-    e.getMessageStatus() == MessageStatus.NOT_AUTHORIZED
+    def e = thrown(FacilityException)
   }
 }

--- a/messaging/src/test/groovy/com/mx/path/connect/messaging/remote/RemoteCRUDModelTest.groovy
+++ b/messaging/src/test/groovy/com/mx/path/connect/messaging/remote/RemoteCRUDModelTest.groovy
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*
 import com.mx.path.connect.messaging.MessageResponse
 import com.mx.path.core.common.facility.FacilityException
 import com.mx.path.core.common.messaging.MessageBroker
+import com.mx.path.core.common.messaging.MessageBrokerException
 import com.mx.path.core.common.messaging.MessageError
 import com.mx.path.core.common.messaging.MessageStatus
 import com.mx.path.core.common.model.ModelList
@@ -191,6 +192,6 @@ class RemoteCRUDModelTest extends Specification {
     subject.create(account)
 
     then:
-    def e = thrown(FacilityException)
+    def e = thrown(MessageBrokerException)
   }
 }


### PR DESCRIPTION
# Summary of Changes


- Recreated Timeout Error: Stopped the NATs in local and executed `authenticateStart.http` to trigger the timeout error.
- Updated Exception Handling: Created a new custom exception class, MessageBrokerException, in path.core to enhance messageError.
- Test Class Adjustments**: Made corresponding updates to the related test classes.
- Local Testing: Successfully tested the NATs exception in `test-connector`, confirming that the internal error flag appears in the header.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
