### PR TITLE
fix: logic error on request_method logging

### DIFF
--- a/gateway/src/main/java/com/mx/path/gateway/util/UpstreamLogger.java
+++ b/gateway/src/main/java/com/mx/path/gateway/util/UpstreamLogger.java
@@ -85,7 +85,7 @@ public class UpstreamLogger {
 
     Request request = response.getRequest();
     MDC.put("request_method", request.getMethod());
-    if (Strings.isNullOrEmpty(request.getMethod())) {
+    if (!Strings.isNullOrEmpty(request.getMethod())) {
       MDC.put("method", request.getMethod().toUpperCase()); // Duplicated and upcased for consistency with other logs
     } else {
       MDC.remove("method");


### PR DESCRIPTION
# Summary of Changes

The logic around logging of request_method is backwards.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
