### PR TITLE
fix: setting originatingIpAddress for requestContext

### DIFF
--- a/context/src/main/java/com/mx/path/core/context/RequestContext.java
+++ b/context/src/main/java/com/mx/path/core/context/RequestContext.java
@@ -1,5 +1,11 @@
 package com.mx.path.core.context;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
 import lombok.AllArgsConstructor;
@@ -96,6 +102,27 @@ public class RequestContext {
    */
   @Setter
   private String originatingIP;
+
+  /**
+   * Getter returning originating ip address
+   */
+  @SuppressWarnings("PMD.EmptyCatchBlock")
+  public String getOriginatingIP() {
+    if (originatingIP == null) {
+      try {
+        URL url = new URL("https://api.ipify.org"); // Public IP service URL
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        urlConnection.setRequestMethod("GET");
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), StandardCharsets.UTF_8));
+        originatingIP = in.readLine();
+        in.close();
+      } catch (IOException e) {
+        //Do nothing as we don't want to obstruct the flow
+      }
+    }
+    return originatingIP;
+  }
 
   /**
    * Request path.

--- a/gateway/src/main/java/com/mx/path/gateway/context/GatewayRequestContext.java
+++ b/gateway/src/main/java/com/mx/path/gateway/context/GatewayRequestContext.java
@@ -39,6 +39,7 @@ public final class GatewayRequestContext extends RequestContext {
    *
    * @return GatewayRequestContext
    */
+  @SuppressWarnings("EmptyCatchBlock")
   public static GatewayRequestContext current() {
     RequestContext requestContext = RequestContext.current();
     if (requestContext == null) {
@@ -54,6 +55,7 @@ public final class GatewayRequestContext extends RequestContext {
         requestContext.setOriginatingIP(in.readLine());
         in.close();
       } catch (IOException e) {
+        //Do nothing as we don't want to obstruct the flow
       }
     }
     return fromRequestContext(requestContext);

--- a/gateway/src/main/java/com/mx/path/gateway/context/GatewayRequestContext.java
+++ b/gateway/src/main/java/com/mx/path/gateway/context/GatewayRequestContext.java
@@ -1,5 +1,12 @@
 package com.mx.path.gateway.context;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
@@ -8,13 +15,6 @@ import com.mx.path.core.common.model.ModelBase;
 import com.mx.path.core.context.RequestContext;
 import com.mx.path.gateway.Gateway;
 import com.mx.path.gateway.accessor.Accessor;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Decorates RequestContext with Gateway-specific fields.
@@ -39,7 +39,7 @@ public final class GatewayRequestContext extends RequestContext {
    *
    * @return GatewayRequestContext
    */
-  @SuppressWarnings("EmptyCatchBlock")
+  @SuppressWarnings("PMD.EmptyCatchBlock")
   public static GatewayRequestContext current() {
     RequestContext requestContext = RequestContext.current();
     if (requestContext == null) {

--- a/gateway/src/main/java/com/mx/path/gateway/context/GatewayRequestContext.java
+++ b/gateway/src/main/java/com/mx/path/gateway/context/GatewayRequestContext.java
@@ -1,12 +1,5 @@
 package com.mx.path.gateway.context;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
@@ -39,24 +32,10 @@ public final class GatewayRequestContext extends RequestContext {
    *
    * @return GatewayRequestContext
    */
-  @SuppressWarnings("PMD.EmptyCatchBlock")
   public static GatewayRequestContext current() {
     RequestContext requestContext = RequestContext.current();
     if (requestContext == null) {
       return null;
-    }
-    if (requestContext.getOriginatingIP() == null) {
-      try {
-        URL url = new URL("https://api.ipify.org"); // Public IP service URL
-        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-        urlConnection.setRequestMethod("GET");
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), StandardCharsets.UTF_8));
-        requestContext.setOriginatingIP(in.readLine());
-        in.close();
-      } catch (IOException e) {
-        //Do nothing as we don't want to obstruct the flow
-      }
     }
     return fromRequestContext(requestContext);
   }

--- a/gateway/src/main/java/com/mx/path/gateway/context/GatewayRequestContext.java
+++ b/gateway/src/main/java/com/mx/path/gateway/context/GatewayRequestContext.java
@@ -9,6 +9,13 @@ import com.mx.path.core.context.RequestContext;
 import com.mx.path.gateway.Gateway;
 import com.mx.path.gateway.accessor.Accessor;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Decorates RequestContext with Gateway-specific fields.
  *
@@ -36,6 +43,18 @@ public final class GatewayRequestContext extends RequestContext {
     RequestContext requestContext = RequestContext.current();
     if (requestContext == null) {
       return null;
+    }
+    if (requestContext.getOriginatingIP() == null) {
+      try {
+        URL url = new URL("https://api.ipify.org"); // Public IP service URL
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        urlConnection.setRequestMethod("GET");
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), StandardCharsets.UTF_8));
+        requestContext.setOriginatingIP(in.readLine());
+        in.close();
+      } catch (IOException e) {
+      }
     }
     return fromRequestContext(requestContext);
   }

--- a/messaging/src/test/groovy/com/mx/path/connect/messaging/remote/RemoteServiceTest.groovy
+++ b/messaging/src/test/groovy/com/mx/path/connect/messaging/remote/RemoteServiceTest.groovy
@@ -225,7 +225,7 @@ class RemoteServiceTest extends Specification {
     def asserter = {
       ->
       def requestContext = RequestContext.current()
-      assert requestContext.originatingIP == null
+      assert requestContext.originatingIP != null
       assert requestContext.sessionTraceId == null
       assert requestContext.feature == null
       assert requestContext.deviceTraceId == null


### PR DESCRIPTION
# Summary of Changes

Today, the default behavior is an empty string if no value comes along in the aggregation or mobile requests for `x-forwarded-for`, which is being considered for originatingIpAddress in core. We rather pass the connector the public IpAddress as the originatingIpaddress in the RequestContext model.

MR that handles it in FHB accessor(as per client requirement): [SAML single sign-on for MX Technologies · GitLab](https://gitlab.com/mxtechnologies/path/path-accessor-q2-uux/-/merge_requests/125) 

We want to keep it generic so that it can be reusable for any such requirement in the future as well.

Fixes [# (issue)](https://mxcom.atlassian.net/browse/IM-182)

k8's https://gitlab.mx.com/mx/platform/k8s/-/merge_requests/4657/diffs

## Public API Additions/Changes

Not related to a specific API

## Downstream Consumer Impact
This is not a breaking change. No downstream consumer impact.

# How Has This Been Tested?

Tested this change via path-accessor-q2-uux, which uses `RequestContext.current().getOriginatingIP()` in the `authenticateWithUserKey` scenario and made sure an ipaddress is always sent and is never null.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
