### PR TITLE
fix: initialize facilities when facilities are empty

### DIFF
--- a/gateway/src/main/java/com/mx/path/gateway/configuration/Configurator.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/Configurator.java
@@ -280,53 +280,51 @@ public abstract class Configurator<T extends Gateway<?>> {
 
   private void populateFacilities(String clientId, ObjectMap map) {
     ObjectMap node = map.getMap("facilities");
-    if (node == null) {
-      return;
-    }
 
     state.withLevel("facilities", () -> {
-      node.keySet().forEach(key -> {
-        switch (key) {
-          case "cacheStore":
-            Facilities.setCacheStore(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, Store.class));
-            break;
+      if (node != null) {
+        node.keySet().forEach(key -> {
+          switch (key) {
+            case "cacheStore":
+              Facilities.setCacheStore(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, Store.class));
+              break;
 
-          case "encryptionService":
-            Facilities.setEncryptionService(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, EncryptionService.class));
-            break;
+            case "encryptionService":
+              Facilities.setEncryptionService(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, EncryptionService.class));
+              break;
 
-          case "eventBus":
-            Facilities.addEventBus(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, EventBus.class));
-            break;
+            case "eventBus":
+              Facilities.addEventBus(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, EventBus.class));
+              break;
 
-          case "exceptionReporter":
-            Facilities.setExceptionReporter(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, ExceptionReporter.class));
-            break;
+            case "exceptionReporter":
+              Facilities.setExceptionReporter(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, ExceptionReporter.class));
+              break;
 
-          case "faultTolerantExecutor":
-            Facilities.setFaultTolerantExecutor(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, FaultTolerantExecutor.class));
-            break;
+            case "faultTolerantExecutor":
+              Facilities.setFaultTolerantExecutor(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, FaultTolerantExecutor.class));
+              break;
 
-          case "messageBroker":
-            Facilities.setMessageBroker(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, MessageBroker.class));
-            break;
+            case "messageBroker":
+              Facilities.setMessageBroker(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, MessageBroker.class));
+              break;
 
-          case "sessionStore":
-            Facilities.setSessionStore(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, Store.class));
-            break;
+            case "sessionStore":
+              Facilities.setSessionStore(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, Store.class));
+              break;
 
-          case "secretStore":
-            Facilities.setSecretStore(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, Store.class));
-            break;
+            case "secretStore":
+              Facilities.setSecretStore(clientId, gatewayObjectConfigurator.buildFromNode(node.getMap(key), clientId, Store.class));
+              break;
 
-          default:
-            throw new GatewayException("Invalid facility: " + key);
-        }
-      });
+            default:
+              throw new GatewayException("Invalid facility: " + key);
+          }
+        });
+      }
     });
 
     ensureDefaultFacilities(clientId);
-
     getObserver().notifyClientFacilitiesInitialized(clientId);
   }
 

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfiguratorTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConfiguratorTest.groovy
@@ -78,4 +78,24 @@ class ConfiguratorTest extends Specification {
     gateways.get("client")
     verify(observer, times(1)).notifyClientFacilitiesInitialized("client")
   }
+
+  def "invokes facilities initialized listeners when facilities are empty"() {
+    given:
+    def yaml =
+        "client:\n" +
+        "  accessor:\n" +
+        "    class: com.mx.testing.accessors.BaseAccessor\n" +
+        "    scope: singleton\n" +
+        "  gateways:\n" +
+        "    id: {}\n" +
+        "    accounts: {}\n"
+
+    when:
+    Map<String, TestGateway> gateways = subject.buildFromYaml(yaml)
+
+    then:
+    gateways.get("client") != null
+    gateways.get("client")
+    verify(observer, times(1)).notifyClientFacilitiesInitialized("client")
+  }
 }


### PR DESCRIPTION
# Summary of Changes

Facility defaults not being applied if there was no `facilities:` node in gateway.yaml. This fixes the logic to still apply defaults if no node is present. This bug will present itself when we start moving apps to use facility defaults.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
