### PR TITLE
fix: bump connectTimeout to 10s from 5s

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/connect/Request.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/Request.java
@@ -67,7 +67,7 @@ public abstract class Request<REQ extends Request<?, ?>, RESP extends Response<?
     STRING_AND_RAW
   }
 
-  private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofMillis(5000);
+  private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofMillis(10000);
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMillis(30000);
 
   // Fields


### PR DESCRIPTION
# Summary of Changes

Bumps default connectTimeout from 5s to 10s

Fixes # (https://mxcom.atlassian.net/browse/MC-4517)

## Public API Additions/Changes

None

## Downstream Consumer Impact

Reduces number of unnecessary timeouts due to connect slower than 5 seconds

# How Has This Been Tested?

Explicitly configured connectTimeout in local `path-connector-first-foundation`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
