### PR TITLE
feat: add upstream response exceptions

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/accessor/ResponsePayloadException.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/ResponsePayloadException.java
@@ -6,12 +6,12 @@ import com.mx.path.core.common.exception.PathRequestException;
  * Thrown when an upstream response payload is unrecognizable or un-processable
  *
  * <p>See {@link PathRequestException} for usage details
+ *
+ * @deprecated Use {@link UpstreamResponseException} children instead.
  */
+@Deprecated
 public class ResponsePayloadException extends AccessorSystemException {
-
   /**
-   * Build new {@link ResponsePayloadException} with specified parameters.
-   *
    * @param message message
    */
   public ResponsePayloadException(String message) {
@@ -21,8 +21,6 @@ public class ResponsePayloadException extends AccessorSystemException {
   }
 
   /**
-   * Build new {@link ResponsePayloadException} with specified parameters.
-   *
    * @param message message
    * @param cause cause
    */

--- a/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseError.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseError.java
@@ -1,0 +1,17 @@
+package com.mx.path.core.common.accessor;
+
+/**
+ * Use when the upstream response is an error that is not user-correctable
+ * <br/>
+ * This indicates that we have determined that the response represents an error from the upstream-side that is not
+ * due to request validation.
+ */
+public class UpstreamResponseError extends UpstreamResponseException {
+  public UpstreamResponseError(String message) {
+    super(message);
+  }
+
+  public UpstreamResponseError(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseException.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseException.java
@@ -1,0 +1,16 @@
+package com.mx.path.core.common.accessor;
+
+/**
+ * Base class for exceptions related to upstream responses
+ */
+public abstract class UpstreamResponseException extends AccessorSystemException {
+  public UpstreamResponseException(String message) {
+    super(message);
+    withStatus(PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
+  }
+
+  public UpstreamResponseException(String message, Throwable cause) {
+    super(message, cause);
+    withStatus(PathResponseStatus.UPSTREAM_SERVICE_UNAVAILABLE);
+  }
+}

--- a/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseProcessingException.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseProcessingException.java
@@ -1,0 +1,20 @@
+package com.mx.path.core.common.accessor;
+
+/**
+ * Thrown when an unknown error occurs while processing the response
+ * <br/>
+ * This exception indicates that the accessor encountered an internal error while processing a response.
+ */
+public class UpstreamResponseProcessingException extends UpstreamResponseException {
+  public UpstreamResponseProcessingException(String message) {
+    super(message);
+    withReport(true);
+    withStatus(PathResponseStatus.INTERNAL_ERROR);
+  }
+
+  public UpstreamResponseProcessingException(String message, Throwable cause) {
+    super(message, cause);
+    withReport(true);
+    withStatus(PathResponseStatus.INTERNAL_ERROR);
+  }
+}

--- a/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseUnprocessableException.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseUnprocessableException.java
@@ -1,0 +1,18 @@
+package com.mx.path.core.common.accessor;
+
+/**
+ * Thrown when an upstream response payload is not processable (e.g. unexpected format)
+ * <br/>
+ * Do not use if a payload value is invalid. Use {@link UpstreamResponseValidationException} instead
+ */
+public class UpstreamResponseUnprocessableException extends UpstreamResponseException {
+  public UpstreamResponseUnprocessableException(String message) {
+    super(message);
+    withReport(true);
+  }
+
+  public UpstreamResponseUnprocessableException(String message, Throwable cause) {
+    super(message, cause);
+    withReport(true);
+  }
+}

--- a/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseValidationException.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/UpstreamResponseValidationException.java
@@ -1,0 +1,19 @@
+package com.mx.path.core.common.accessor;
+
+/**
+ * Thrown when a critical value in a response is invalid and no fallback or default is available
+ * <br/>
+ * These exceptions indicate that the API contract may have changed and will require investigation by MX and the owner
+ * of the upstream API.
+ */
+public class UpstreamResponseValidationException extends UpstreamResponseException {
+  public UpstreamResponseValidationException(String message, Throwable cause) {
+    super(message, cause);
+    withReport(true);
+  }
+
+  public UpstreamResponseValidationException(String message) {
+    super(message);
+    withReport(true);
+  }
+}

--- a/common/src/main/java/com/mx/path/core/common/accessor/UpstreamSystemUnavailable.java
+++ b/common/src/main/java/com/mx/path/core/common/accessor/UpstreamSystemUnavailable.java
@@ -7,9 +7,8 @@ import com.mx.path.core.common.exception.PathRequestException;
  *
  * <p>This can be used as a catch-all exception for situations where something went bad upstream,
  * usually resulting in an unexpected status code, and we couldn't figure out why. This is close relative to
- * {@link ResponsePayloadException}. The difference is that {@link ResponsePayloadException} indicates that we were
- * unable to process a response that was expected to be good. This exception is a bit more general and used when
- * we can determine that the response is not right.
+ * children of {@link UpstreamResponseException}. The difference is that {@link UpstreamResponseException} indicates
+ * specific reasons that we were unable to process a response that was expected to be good.
  *
  * <p>Consider the following code example. In this example, we are attempting to determine why the response did not have
  * a 200 OK status. Keep in mind, this is upstream-system-specific. Determining what happened, may not
@@ -26,7 +25,7 @@ import com.mx.path.core.common.exception.PathRequestException;
  *   } else if ("internal".equals(code)) {
  *     thrown new UpstreamSystemUnavailable("Bank system error", "Bank system failed to process request. Please try again later.")
  *   } else { // default
- *     thrown new UpstreamSystemUnavailable("Bank system unknown state", "Bank system failed to process request. Please try again later.")
+ *     thrown new UpstreamResponseValidationException("Bank system unknown state", "Bank system failed to process request. Please try again later.")
  *   }
  * }
  * }</pre>

--- a/common/src/main/java/com/mx/path/core/common/exception/PathRequestException.java
+++ b/common/src/main/java/com/mx/path/core/common/exception/PathRequestException.java
@@ -15,8 +15,12 @@ import com.mx.path.core.common.accessor.PathResponseStatus;
 import com.mx.path.core.common.accessor.RequestPayloadException;
 import com.mx.path.core.common.accessor.RequestValidationException;
 import com.mx.path.core.common.accessor.ResourceNotFoundException;
-import com.mx.path.core.common.accessor.ResponsePayloadException;
 import com.mx.path.core.common.accessor.UnauthorizedException;
+import com.mx.path.core.common.accessor.UpstreamResponseError;
+import com.mx.path.core.common.accessor.UpstreamResponseException;
+import com.mx.path.core.common.accessor.UpstreamResponseProcessingException;
+import com.mx.path.core.common.accessor.UpstreamResponseUnprocessableException;
+import com.mx.path.core.common.accessor.UpstreamResponseValidationException;
 import com.mx.path.core.common.accessor.UpstreamSystemMaintenance;
 import com.mx.path.core.common.accessor.UpstreamSystemUnavailable;
 import com.mx.path.core.common.connect.CircuitOpenException;
@@ -49,9 +53,13 @@ import com.mx.path.core.common.messaging.MessageError;
  *     {@link AccessorSystemException} - Base class for exceptions thrown on unrecoverable error in accessor code
  *       {@link AccessorMethodNotImplementedException} - Thrown when an accessor method is invoked that has no implementation
  *       {@link RequestPayloadException} - Thrown when an upstream request payload cannot be built
- *       {@link ResponsePayloadException} - Thrown when an upstream response payload is unrecognizable or un-processable
  *       {@link UpstreamSystemUnavailable} - Thrown when an upstream request results in an unknown error or the upstream service is determined to be offline
  *         {@link UpstreamSystemMaintenance} - Thrown when the upstream system is determined to be offline due to maintenance
+ *       {@link UpstreamResponseException} - Base class for exceptions related to upstream responses
+ *         {@link UpstreamResponseError} - Thrown when upstream response is an error that is not user-correctable
+ *         {@link UpstreamResponseUnprocessableException} - Thrown when an upstream response payload is not processable (e.g. unexpected format)
+ *         {@link UpstreamResponseValidationException} - Thrown when a critical value in a response is invalid and no fallback or default is available
+ *         {@link UpstreamResponseProcessingException} - Thrown when an unknown error occurs while processing the response
  *   {@link ConnectException} - Thrown on error in connection code
  *     {@link TimeoutException} - Thrown on a connection/request timeout
  *     {@link ServiceUnavailableException} - Thrown when a service (typically upstream service) is unavailable. The unavailability could be determined by a response from the service or something on the client side

--- a/gateway/src/main/java/com/mx/path/gateway/util/SoapMarshaller.java
+++ b/gateway/src/main/java/com/mx/path/gateway/util/SoapMarshaller.java
@@ -17,7 +17,7 @@ import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPMessage;
 
 import com.mx.path.core.common.accessor.RequestPayloadException;
-import com.mx.path.core.common.accessor.ResponsePayloadException;
+import com.mx.path.core.common.accessor.UpstreamResponseUnprocessableException;
 
 /**
  * Static methods for marshalling to and from SOAP Envelopes
@@ -121,7 +121,7 @@ public class SoapMarshaller {
 
       return response.getValue();
     } catch (JAXBException | IOException | SOAPException ex) {
-      throw new ResponsePayloadException(ex.getMessage(), ex);
+      throw new UpstreamResponseUnprocessableException(ex.getMessage(), ex);
     }
   }
 }


### PR DESCRIPTION
# Summary of Changes

Add new sub-class of exceptions for upstream errors. These will help us better-categorize errors related to upstream system responses.

Also deprecating `ResponsePayloadException` since it is being replaced with the new, more specific exceptions.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
