### PR TITLE
fix: remove unnecessary tab from beginning of UpstreamLogger output

### DIFF
--- a/gateway/src/main/java/com/mx/path/gateway/util/UpstreamLogger.java
+++ b/gateway/src/main/java/com/mx/path/gateway/util/UpstreamLogger.java
@@ -216,7 +216,7 @@ public class UpstreamLogger {
 
   private String buildApiPayload(Response response, Request request) {
     StringBuilder b = new StringBuilder();
-    b.append("= Request\n\n");
+    b.append("\n= Request\n\n");
     b.append(request.getMethod());
     b.append(" ");
     b.append(LOGMASKER.maskPayload(request.getUri()));


### PR DESCRIPTION
# Summary of Changes

Remove unnecessary tab at the beginning of UpstreamLogger api_call_payload

## Public API Additions/Changes

None

## Downstream Consumer Impact

None

# How Has This Been Tested?

Tested locally via SNAPSHOT versions, verified console output

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
