### PR TITLE
fix: get connection timeout values from config

### DIFF
--- a/common/src/main/java/com/mx/path/core/common/connect/ConnectionSettings.java
+++ b/common/src/main/java/com/mx/path/core/common/connect/ConnectionSettings.java
@@ -54,7 +54,7 @@ public interface ConnectionSettings {
   Duration getRequestTimeout();
 
   /**
-   * @return true, if host name should be checked against the certificate
+   * @return true if host name should NOT be checked against the certificate, false otherwise
    */
   boolean getSkipHostNameVerify();
 

--- a/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
+++ b/common/src/main/java/com/mx/path/core/common/reflection/Fields.java
@@ -105,6 +105,10 @@ public class Fields {
       return null;
     }
 
+    if (targetType == value.getClass()) {
+      return value;
+    }
+
     if (targetType == byte.class || targetType == Byte.class) {
       return coerceToByte(value);
     }

--- a/gateway/src/main/java/com/mx/path/gateway/configuration/ConnectionBinder.java
+++ b/gateway/src/main/java/com/mx/path/gateway/configuration/ConnectionBinder.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import com.mx.path.core.common.collection.ObjectMap;
 import com.mx.path.core.common.connect.AccessorConnectionSettings;
 import com.mx.path.core.common.gateway.GatewayException;
+import com.mx.path.core.common.lang.Durations;
 import com.mx.path.core.common.lang.Strings;
 import com.mx.path.gateway.connect.filter.CallbacksFilter;
 import com.mx.path.gateway.connect.filter.ErrorHandlerFilter;
@@ -64,7 +65,15 @@ public class ConnectionBinder {
     if (passwordString != null) {
       connection.keystorePassword(passwordString.toCharArray());
     }
-    connection.skipHostNameVerify(Boolean.parseBoolean(String.valueOf(map.getMap(connectionName).get("skipHostNameVerify"))));
+    String connectTimeoutString = map.getMap(connectionName).getAsString("connectTimeout");
+    if (connectTimeoutString != null) {
+      connection.connectTimeout(Durations.fromCompactString(connectTimeoutString));
+    }
+    String requestTimeoutString = map.getMap(connectionName).getAsString("requestTimeout");
+    if (requestTimeoutString != null) {
+      connection.requestTimeout(Durations.fromCompactString(requestTimeoutString));
+    }
+    connection.skipHostNameVerify(map.getMap(connectionName).getAsBoolean("skipHostNameVerify", false));
 
     // Default request filters
     // todo: Provide way to configure the request filters in connection block

--- a/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConnectionBinderTest.groovy
+++ b/gateway/src/test/groovy/com/mx/path/gateway/configuration/ConnectionBinderTest.groovy
@@ -1,11 +1,15 @@
 package com.mx.path.gateway.configuration
 
+import java.time.Duration
+
 import com.mx.path.core.common.accessor.PathResponseStatus
 import com.mx.path.core.common.collection.ObjectMap
+import com.mx.path.core.common.configuration.ConfigurationException
 import com.mx.path.core.common.gateway.GatewayException
 import com.mx.testing.binding.ConnectionWithBoundConfiguration
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ConnectionBinderTest extends Specification {
 
@@ -40,6 +44,9 @@ class ConnectionBinderTest extends Specification {
       certificateAlias == "alias"
       keystorePath == "path"
       keystorePassword.toString() == "password"
+      connectTimeout == null
+      requestTimeout == null
+      !skipHostNameVerify
     }
   }
 
@@ -73,6 +80,9 @@ class ConnectionBinderTest extends Specification {
         put("certificateAlias", "alias")
         put("keystorePath", "path")
         put("keystorePassword", "password")
+        put("connectTimeout", "500ms")
+        put("requestTimeout", "20s")
+        put("skipHostNameVerify", true)
       }
     }
 
@@ -85,7 +95,34 @@ class ConnectionBinderTest extends Specification {
       certificateAlias == "alias"
       keystorePath == "path"
       keystorePassword.toString() == "password"
+      connectTimeout == Duration.ofMillis(500)
+      requestTimeout == Duration.ofSeconds(20)
+      skipHostNameVerify
     }
+  }
+
+  @Unroll
+  def "build connection throws on invalid #fieldName format"(String fieldName) {
+    given:
+    def configuration = new ObjectMap().tap {
+      createMap("TestConnection").tap {
+        put("baseUrl", "url")
+        put(fieldName, "not-a-valid-duration")
+      }
+    }
+
+    when:
+    subject.buildConnection(configuration, "TestConnection")
+
+    then:
+    def e = thrown(ConfigurationException)
+    e.message == "Invalid duration string: not-a-valid-duration"
+
+    where:
+    fieldName << [
+      "connectTimeout",
+      "requestTimeout"
+    ]
   }
 
   def "build connection and fail validation"() {


### PR DESCRIPTION
# Summary of Changes

Fixed a bug where connection timeout configurations defined in `gateway.yaml` were being ignored during application startup. 

Previously, even if `connectTimeout` and `requestTimeout` were provided in the configuration file, they were not being mapped to the `AccessorConnectionSettings`, resulting in those values remaining null and having no effect on connection requests. This change updates `ConnectionBinder` to correctly extract those strings from the configuration map, parse them using `Durations.fromCompactString()`, and apply them to the underlying connection settings.

Additionally, I fixed an issue with `Fields.coerceValueType` where it would fail to coerce `Duration` values if the value was already a `Duration` type. I added the following code after the null check to handle any values that don't need to be coerced because they are already of the desired type. This also provides a small performance improvement, since no additional processing is required to "coerce" a value unnecessarily. 

```java
    if (targetType == value.getClass()) {
      return value;
    }
```

Fixes [GCU-1311](https://mxcom.atlassian.net/browse/GCU-1311)

## Public API Additions/Changes

None

## Downstream Consumer Impact

Downstream consumers will now see their configured `connectTimeout` and `requestTimeout` values actively applied to connections. Previously, these settings were silently ignored.

Additionally, consumers should be aware that if an invalid duration string is provided in the configuration file, the application will now fail-fast during Spring Boot initialization by throwing a `ConfigurationException` detailing the invalid format.

# How Has This Been Tested?

I created a snapshot version and pulled it into path-connector-hancock-whitney. I also updated the `gateway.yaml` to include a `connectTimeout` and `requestTimeout` for the `MdxRealtimeConnection` connection. While using the snapshot version of `path-core`, I was able to verify that the timeout configurations were being applied to the connection.

<img width="1292" height="392" alt="image" src="https://github.com/user-attachments/assets/e690121f-8c2d-49b1-9806-d8c8816df59e" />

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works


[GCU-1311]: https://mxcom.atlassian.net/browse/GCU-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ