### PR TITLE
fix: trigger re-release after vogue hotfix

### DIFF
--- a/common/gradle.lockfile
+++ b/common/gradle.lockfile
@@ -100,4 +100,4 @@ org.spockframework:spock-core:2.4-M6-groovy-3.0=testCompileClasspath,testRuntime
 org.xmlresolver:xmlresolver:5.2.2=checkstyle
 org.xmlresolver:xmlresolver:5.3.3=pmd,spotbugs
 org.yaml:snakeyaml:2.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-empty=signatures,spotbugsPlugins
+empty=spotbugsPlugins

--- a/context/gradle.lockfile
+++ b/context/gradle.lockfile
@@ -111,4 +111,4 @@ org.xmlresolver:xmlresolver:5.3.3=pmd,spotbugs
 org.yaml:snakeyaml:2.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 uk.org.webcompere:system-stubs-core:2.1.5=testCompileClasspath,testRuntimeClasspath
 uk.org.webcompere:system-stubs-jupiter:2.1.5=testCompileClasspath,testRuntimeClasspath
-empty=signatures,spotbugsPlugins
+empty=spotbugsPlugins

--- a/gateway-generator/gradle.lockfile
+++ b/gateway-generator/gradle.lockfile
@@ -131,4 +131,4 @@ org.spockframework:spock-core:2.4-M6-groovy-3.0=testCompileClasspath,testRuntime
 org.xmlresolver:xmlresolver:5.2.2=checkstyle
 org.xmlresolver:xmlresolver:5.3.3=pmd,spotbugs
 org.yaml:snakeyaml:2.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-empty=signatures,spotbugsPlugins
+empty=spotbugsPlugins

--- a/gateway/gradle.lockfile
+++ b/gateway/gradle.lockfile
@@ -126,4 +126,4 @@ org.spockframework:spock-core:2.4-M6-groovy-3.0=testCompileClasspath,testRuntime
 org.xmlresolver:xmlresolver:5.2.2=checkstyle
 org.xmlresolver:xmlresolver:5.3.3=pmd,spotbugs
 org.yaml:snakeyaml:2.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-empty=signatures,spotbugsPlugins
+empty=spotbugsPlugins

--- a/http/gradle.lockfile
+++ b/http/gradle.lockfile
@@ -127,4 +127,4 @@ org.spockframework:spock-core:2.4-M6-groovy-3.0=testCompileClasspath,testRuntime
 org.xmlresolver:xmlresolver:5.2.2=checkstyle
 org.xmlresolver:xmlresolver:5.3.3=pmd,spotbugs
 org.yaml:snakeyaml:2.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-empty=signatures,spotbugsPlugins
+empty=spotbugsPlugins

--- a/messaging/gradle.lockfile
+++ b/messaging/gradle.lockfile
@@ -111,4 +111,4 @@ org.spockframework:spock-core:2.4-M6-groovy-3.0=testCompileClasspath,testRuntime
 org.xmlresolver:xmlresolver:5.2.2=checkstyle
 org.xmlresolver:xmlresolver:5.3.3=pmd,spotbugs
 org.yaml:snakeyaml:2.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-empty=signatures,spotbugsPlugins
+empty=spotbugsPlugins

--- a/testing/gradle.lockfile
+++ b/testing/gradle.lockfile
@@ -125,4 +125,4 @@ org.spockframework:spock-core:2.4-M6-groovy-3.0=compileClasspath,runtimeClasspat
 org.xmlresolver:xmlresolver:5.2.2=checkstyle
 org.xmlresolver:xmlresolver:5.3.3=pmd,spotbugs
 org.yaml:snakeyaml:2.4=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-empty=signatures,spotbugsPlugins
+empty=spotbugsPlugins

--- a/utilities/gradle.lockfile
+++ b/utilities/gradle.lockfile
@@ -95,4 +95,4 @@ org.spockframework:spock-bom:2.4-M6-groovy-3.0=testCompileClasspath,testRuntimeC
 org.spockframework:spock-core:2.4-M6-groovy-3.0=testCompileClasspath,testRuntimeClasspath
 org.xmlresolver:xmlresolver:5.2.2=checkstyle
 org.xmlresolver:xmlresolver:5.3.3=pmd,spotbugs
-empty=signatures,spotbugsPlugins
+empty=spotbugsPlugins


### PR DESCRIPTION
# Summary of Changes

vogue update somehow caused jackson-core to look for non existent v2.22.0, causing release to fail. Vogue 4.0.1 resolves that issue, this MR will properly release the gradle 8 and java 21 changes for path-core

[MC-12414](https://mxcom.atlassian.net/browse/MC-12414)

## Public API Additions/Changes

None

## Downstream Consumer Impact

None

# How Has This Been Tested?

Verified locally against Wedge/Abagnale

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works


[MC-12414]: https://mxcom.atlassian.net/browse/MC-12414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ